### PR TITLE
Feature/housekeeping

### DIFF
--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -1,4 +1,44 @@
+# 3.0.0
+
+## Changes
+
+* Lots of new stories! 📖✨
+* Stories are no longer co-located with components (GreyVest alone is much smaller and flatter than contexture-react, so it makes more sense to keep them separate)
+* New typography components: **Text**, **Title** and **Subtitle**
+* Other new components: **Dropdown** (a zero-padding variant of Popover intended to be used with DropdownItem), **Tooltip**, and **Divider**
+* Changes to **Button**:
+  * New component-level variants: **Button.Primary**, **Button.Secondary** (same as regular Button), **Button.Tertiary**, **Button.Danger**, and **Button.Ghost**
+  * New props: `compact` and `large` flags for size variants, and `icon` (same as the Icon component's `icon` prop)
+* Changes to **Box**:
+  * New component-level variants: **Box.Modal** and **Box.Popup** (different shadow styles)
+  * New props: `p`, `px`, and `py`
+* New props on **DropdownItem**: `disabled`, `truncate`, and `icon` (same as the Icon component's `icon` prop)
+* Changes to **Modal**:
+  * New subcomponents: **Modal.Header**, **Modal.Content**, and **Modal.Footer**
+  * Modals now have a close button and can additionally be closed with the `Esc` key
+* Changes to **TextInput**, **Textarea**, and **Select**:
+  * Now properly handle the `disabled` prop
+  * No longer default to 100% width
+* Expanded the `options` prop API (for **CheckboxList**, **RadioList**, and **Select**): in addition to `label` and `value`, each element now also accepts a boolean `disabled` property
+* **DateInput** now includes a time picker (now uses `react-datetime-picker` internally instead of `react-date-picker`)
+
+### Spacing props
+
+Component props that control whitespace now take spacing values from GreyVest's design system instead of pixel measurements. These props can take either a number which is multiplied by `8` to produce a size in pixels, or one of the following string aliases:
+
+* `xs`: 4px
+* `sm`: 8px
+* `md`: 16px
+* `lg`: 32px
+
+| Component | Prop(s)                                            | Status                                           |
+| --------- | -------------------------------------------------- | ------------------------------------------------ |
+| Grid      | `gap`                                              | formerly pixel measurement (**breaking change**) |
+| Box       | `padding`, `paddingX`, `paddingY`, `p`, `px`, `py` | new in 3.0                                       |
+| Divider   | `margin`, `m`                                      | new in 3.0                                       |
+
 #### 3.0.0-alpha.5
+
 * Update TextInput, DateInput, Select and Textarea for new design system
 * Add stories for TextInput, DateInput, Select and Textarea
 
@@ -17,7 +57,7 @@
 #### 3.0.0-alpha.1
 * Update Box for new design system
 
-# 3.0.0-alpha.0
+#### 3.0.0-alpha.0
 * Implement new design system
 
 ## 2.10.0

--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -37,6 +37,11 @@ Component props that control whitespace now take spacing values from GreyVest's 
 | Box       | `padding`, `paddingX`, `paddingY`, `p`, `px`, `py` | new in 3.0                                       |
 | Divider   | `margin`, `m`                                      | new in 3.0                                       |
 
+#### 3.0.0-alpha.6
+* Add `withAliasProps` HOC to utils
+* Add prop aliases: `m` -> `margin` in Divider, `padding` -> `p`, `paddingX` -> `px`, `paddingY` -> `py` in Box
+* Add list of changes in 3.0.0 to changelog
+
 #### 3.0.0-alpha.5
 
 * Update TextInput, DateInput, Select and Textarea for new design system

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grey-vest",
-  "version": "3.0.0-alpha.5",
+  "version": "3.0.0-alpha.6",
   "description": "GreyVest component library",
   "main": "dist/index.js",
   "scripts": {

--- a/src/Box.js
+++ b/src/Box.js
@@ -20,7 +20,13 @@ let Box = ({ as: As = 'div', p = 2, px, py, ...props }) => (
     {...props}
   />
 )
-Box.Popup = styled(Box)({ boxShadow: theme.boxShadows.popup })
-Box.Modal = styled(Box)({ boxShadow: theme.boxShadows.modal })
+F.extendOn(
+  Box,
+  F.arrayToObject(
+    _.capitalize,
+    variant => styled(Box)({ boxShadow: theme.boxShadows[variant] }),
+    ['popup', 'modal']
+  )
+)
 
 export default Box

--- a/src/Box.js
+++ b/src/Box.js
@@ -3,10 +3,14 @@ import { jsx } from '@emotion/core'
 import styled from '@emotion/styled'
 import _ from 'lodash/fp'
 import F from 'futil'
-import { coalesce } from './utils'
+import { setDisplayName } from 'recompose'
+import { coalesce, withAliasProps } from './utils'
 import theme from './theme'
 
-let Box = ({ as: As = 'div', p = 2, px, py, ...props }) => (
+let Box = _.flow(
+  setDisplayName('Box'),
+  withAliasProps({ padding: 'p', paddingX: 'px', paddingY: 'py' })
+)(({ as: As = 'div', p = 2, px, py, ...props }) => (
   <As
     css={{
       borderRadius: theme.borderRadius,
@@ -19,7 +23,8 @@ let Box = ({ as: As = 'div', p = 2, px, py, ...props }) => (
     }}
     {...props}
   />
-)
+))
+
 F.extendOn(
   Box,
   F.arrayToObject(

--- a/src/Box.js
+++ b/src/Box.js
@@ -1,17 +1,26 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/core'
+import styled from '@emotion/styled'
 import _ from 'lodash/fp'
-import theme, { withPadding } from './theme'
+import F from 'futil'
+import { coalesce } from './utils'
+import theme from './theme'
 
-let Box = ({ as: As = 'div', variant = 'normal', ...props }) => (
+let Box = ({ as: As = 'div', p = 2, px, py, ...props }) => (
   <As
     css={{
       borderRadius: theme.borderRadius,
       backgroundColor: theme.colors.neutrals[0],
-      boxShadow: _.get(variant, theme.boxShadows),
+      boxShadow: theme.boxShadows.normal,
+      padding: _.flow(
+        F.flowMap(theme.space, F.append('px')),
+        _.join(' ')
+      )([coalesce([py, p]), coalesce([px, p])]),
     }}
     {...props}
   />
 )
+Box.Popup = styled(Box)({ boxShadow: theme.boxShadows.popup })
+Box.Modal = styled(Box)({ boxShadow: theme.boxShadows.modal })
 
-export default withPadding({ p: 2 })(Box)
+export default Box

--- a/src/Box.js
+++ b/src/Box.js
@@ -4,7 +4,7 @@ import styled from '@emotion/styled'
 import _ from 'lodash/fp'
 import F from 'futil'
 import { setDisplayName, renameProps } from 'recompose'
-import { coalesce, withAliasProps } from './utils'
+import { coalesce } from './utils'
 import theme from './theme'
 
 let Box = _.flow(
@@ -24,14 +24,7 @@ let Box = _.flow(
     {...props}
   />
 ))
-
-F.extendOn(
-  Box,
-  F.arrayToObject(
-    _.capitalize,
-    variant => styled(Box)({ boxShadow: theme.boxShadows[variant] }),
-    ['popup', 'modal']
-  )
-)
+Box.Popup = styled(Box)({ boxShadow: theme.boxShadows.popup })
+Box.Modal = styled(Box)({ boxShadow: theme.boxShadows.modal })
 
 export default Box

--- a/src/Box.js
+++ b/src/Box.js
@@ -3,13 +3,13 @@ import { jsx } from '@emotion/core'
 import styled from '@emotion/styled'
 import _ from 'lodash/fp'
 import F from 'futil'
-import { setDisplayName } from 'recompose'
+import { setDisplayName, renameProps } from 'recompose'
 import { coalesce, withAliasProps } from './utils'
 import theme from './theme'
 
 let Box = _.flow(
   setDisplayName('Box'),
-  withAliasProps({ padding: 'p', paddingX: 'px', paddingY: 'py' })
+  renameProps({ padding: 'p', paddingX: 'px', paddingY: 'py' })
 )(({ as: As = 'div', p = 2, px, py, ...props }) => (
   <As
     css={{

--- a/src/Checkbox.js
+++ b/src/Checkbox.js
@@ -24,7 +24,10 @@ let Checkbox = ({
         borderRadius: 3,
         backgroundColor: theme.colors.neutrals[0],
         border: `2px solid ${theme.colors.neutrals[6]}`,
-        '& *': { color: theme.colors.primaries[0] },
+        transition: 'all 0.5s ease',
+        '& i': { 
+          color: checked ? theme.colors.primaries[0] : 'transparent',
+        },
       },
       disabled && {
         borderColor: theme.colors.neutrals[5],
@@ -42,11 +45,11 @@ let Checkbox = ({
       style={{ display: 'none' }}
       {...{ checked, onChange }}
     />
-    {checked ? (
-      <Icon icon="check" size={0} style={{ fontWeight: 900 }} />
-    ) : (
-      String.fromCharCode(160) // non-breaking space
-    )}
+    <Icon
+      icon="check"
+      size={0}
+      style={{ fontWeight: 'bold' }}
+    />
   </Flex>
 )
 export default Checkbox

--- a/src/Divider.js
+++ b/src/Divider.js
@@ -1,10 +1,12 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/core'
 import theme from './theme'
-import { withAliasProps } from './utils'
+import GridItem from './GridItem'
+import { renameProps } from 'recompose'
 
-let Divider = ({ vertical = false, margin = 1 }) => (
-  <div
+let Divider = ({ vertical = false, margin = 1, ...props }) => (
+  <GridItem
+  place={vertical ? "stretch center" : "center stretch"}
     css={[
       {
         backgroundColor: theme.colors.neutrals[3],
@@ -21,7 +23,8 @@ let Divider = ({ vertical = false, margin = 1 }) => (
             marginBottom: theme.space(margin),
           },
     ]}
+    {...props}
   />
 )
 
-export default withAliasProps({ m: 'margin' })(Divider)
+export default renameProps({ m: 'margin' })(Divider)

--- a/src/Divider.js
+++ b/src/Divider.js
@@ -1,6 +1,7 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/core'
 import theme from './theme'
+import { withAliasProps } from './utils'
 
 let Divider = ({ vertical = false, margin = 1 }) => (
   <div
@@ -23,4 +24,4 @@ let Divider = ({ vertical = false, margin = 1 }) => (
   />
 )
 
-export default Divider
+export default withAliasProps({ m: 'margin' })(Divider)

--- a/src/Icon.js
+++ b/src/Icon.js
@@ -3,9 +3,9 @@ import F from 'futil'
 import { Dynamic, TextButton } from '.'
 import theme from './theme'
 
-let SmallIcon = ({ icon, style, size = 2, ...props }) => (
+let SmallIcon = ({ icon, style, size = 2, className, ...props }) => (
   <i
-    className="material-icons"
+    className={`material-icons ${className}`}
     style={{ fontSize: F.alias(size, theme.fontSizes), ...style }}
     {...props}
   >

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -32,8 +32,7 @@ let Modal = _.flow(
         alignItems="center"
         onClick={onClose}
       >
-        <Box
-          variant="modal"
+        <Box.Modal
           p={3}
           onClick={e => e.stopPropagation()}
           css={{ minWidth: 400, maxWidth: 600, position: 'relative' }}
@@ -52,7 +51,7 @@ let Modal = _.flow(
             onClick={onClose}
           />
           {children}
-        </Box>
+        </Box.Modal>
       </Flex>
     )}
   </Portal>

--- a/src/Popover.js
+++ b/src/Popover.js
@@ -15,8 +15,7 @@ let makePopover = padding =>
     ({ isOpen, onClose = _.noop, ...props }) =>
       isOpen && (
         <OutsideClickHandler onOutsideClick={_.debounce(0, onClose)}>
-          <Box
-            variant="popup"
+          <Box.Popup
             {...padding}
             css={{
               position: 'absolute',

--- a/src/stories/Box.stories.js
+++ b/src/stories/Box.stories.js
@@ -53,15 +53,15 @@ export let controlledPadding = () => {
   )
   return (
     <Grid gap={2}>
-      <GreyPaddingBox px={4}>
-        horizontal padding overridden to {theme.space(4)}px
+      <GreyPaddingBox paddingX={4} paddingY="sm">
+        {theme.space(4)}px by {theme.space('sm')}px padding
       </GreyPaddingBox>
-      <GreyPaddingBox py={4}>
-        vertical padding overridden to {theme.space(4)}px
+      <GreyPaddingBox px={1} py="lg">
+        {theme.space(1)}px by {theme.spaces.lg}px padding
       </GreyPaddingBox>
       {_.map(
         padding => (
-          <GreyPaddingBox p={padding}>
+          <GreyPaddingBox padding={padding}>
             {theme.space(padding)}px padding
           </GreyPaddingBox>
         ),

--- a/src/stories/Box.stories.js
+++ b/src/stories/Box.stories.js
@@ -1,7 +1,8 @@
 import React from 'react'
-import { Box, Grid } from '..'
+import { Box, Grid, Text } from '..'
 import _ from 'lodash/fp'
 import decorator from './decorator'
+import theme from '../theme'
 
 export default {
   title: 'Box',
@@ -22,18 +23,50 @@ let Backgrounds = ({ children }) => (
 
 export let normalBox = () => (
   <Backgrounds>
-    <Box>Box Contents</Box>
+    <Box>
+      <Text>Box Contents</Text>
+    </Box>
   </Backgrounds>
 )
 
 export let modalBox = () => (
   <Backgrounds>
-    <Box variant="modal">Box Contents</Box>
+    <Box.Modal>
+      <Text>Box Contents</Text>
+    </Box.Modal>
   </Backgrounds>
 )
 
 export let popupBox = () => (
   <Backgrounds>
-    <Box variant="popup">Box Contents</Box>
+    <Box.Popup>
+      <Text>Box Contents</Text>
+    </Box.Popup>
   </Backgrounds>
 )
+
+export let controlledPadding = () => {
+  let GreyPaddingBox = ({ children, ...props }) => (
+    <Box style={{ background: 'lightgrey' }} {...props}>
+      <Text style={{ background: 'white' }}>{children}</Text>
+    </Box>
+  )
+  return (
+    <Grid gap={2}>
+      <GreyPaddingBox px={4}>
+        horizontal padding overridden to {theme.space(4)}px
+      </GreyPaddingBox>
+      <GreyPaddingBox py={4}>
+        vertical padding overridden to {theme.space(4)}px
+      </GreyPaddingBox>
+      {_.map(
+        padding => (
+          <GreyPaddingBox p={padding}>
+            {theme.space(padding)}px padding
+          </GreyPaddingBox>
+        ),
+        _.range(0, 5)
+      )}
+    </Grid>
+  )
+}

--- a/src/theme.js
+++ b/src/theme.js
@@ -129,21 +129,3 @@ export let inputStyle = {
     backgroundColor: theme.colors.neutrals[2],
   },
 }
-
-// allows the use of p, px and py props to control padding (borrowed from styled-system)
-// usage: withPadding({ p: 1 })(Component)
-//        <Component px={2} py={3} />
-export let withPadding = ({
-  px: pxDefault,
-  py: pyDefault,
-  p: pDefault,
-}) => Component => ({ p, px, py, ...props }) => {
-  let xPadding = coalesce([px, p, pxDefault, pDefault, 0])
-  let yPadding = coalesce([py, p, pyDefault, pDefault, 0])
-  return (
-    <Component
-      css={{ padding: `${theme.space(yPadding)}px ${theme.space(xPadding)}px` }}
-      {...props}
-    />
-  )
-}

--- a/src/theme.js
+++ b/src/theme.js
@@ -1,8 +1,5 @@
-/** @jsx jsx */
-import { jsx } from '@emotion/core'
 import F from 'futil'
 import _ from 'lodash/fp'
-import { coalesce } from './utils'
 
 let spaces = { xs: 4, sm: 8, md: 16, lg: 32 }
 let space = F.ifElse(_.isNumber, n => n * 8, F.aliasIn(spaces))

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,6 @@
 import _ from 'lodash/fp'
 import * as F from 'futil'
-import { useState } from 'react'
+import React, { useState } from 'react'
 import { mapProps } from 'recompose'
 
 export let useLensObject = _.mapValues(useState)
@@ -25,3 +25,11 @@ export let findKeys = _.curry((predicate, data) =>
 )
 
 export let coalesce = _.find(F.isNotNil)
+
+// ({ r: 'red', b: 'blue' g: 'green' }) -> Component<{ red, blue, green }> -> Component<{ red, blue, green, r, g, b }>
+export let withAliasProps = aliases => Component => props => (
+  <Component {..._.mapKeys(F.aliasIn(aliases), props)} />
+)
+// possible futil method?
+// ({ r: 'red', b: 'blue' }) -> ({ r: 5, green: 1 }) -> ({ red: 5, green: 1 })
+// let aliasKeys = aliases => _.mapKeys(F.aliasIn(aliases))

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,6 @@
 import _ from 'lodash/fp'
 import * as F from 'futil'
-import React, { useState } from 'react'
+import { useState } from 'react'
 import { mapProps } from 'recompose'
 
 export let useLensObject = _.mapValues(useState)

--- a/src/utils.js
+++ b/src/utils.js
@@ -25,11 +25,3 @@ export let findKeys = _.curry((predicate, data) =>
 )
 
 export let coalesce = _.find(F.isNotNil)
-
-// ({ r: 'red', b: 'blue' g: 'green' }) -> Component<{ red, blue, green }> -> Component<{ red, blue, green, r, g, b }>
-export let withAliasProps = aliases => Component => props => (
-  <Component {..._.mapKeys(F.aliasIn(aliases), props)} />
-)
-// possible futil method?
-// ({ r: 'red', b: 'blue' }) -> ({ r: 5, green: 1 }) -> ({ red: 5, green: 1 })
-// let aliasKeys = aliases => _.mapKeys(F.aliasIn(aliases))


### PR DESCRIPTION
- add actual 3.0 documentation to changelog
- fix moving checkbox bug
- Box improvements:
  - change modal/popup variant api from `variant` prop to `Box.Modal`/`Box.Popup` (for consistency with other components, eg. buttons)
  - kill `withPadding` HOC, move padding stuff directly into Button component
  - add `withAliasProps` HOC so we can have both `p` and `padding` props (and `m` + `margin` on Divider)