### PR TITLE
[WIP] DataTable

### DIFF
--- a/src/DataTable.js
+++ b/src/DataTable.js
@@ -1,0 +1,46 @@
+import React from 'react'
+import F from 'futil'
+import _ from 'lodash/fp'
+import { Table, LinkButton } from '.'
+
+let DataTable = ({ fields, data, ...props }) => (
+  <Table {...props}>
+    <thead>
+      <tr>
+        {F.mapIndexed(
+          (field, key) => !field.hidden && <th key={key}>{field.label}</th>,
+          fields
+        )}
+      </tr>
+    </thead>
+    <tbody>
+      {F.mapIndexed(
+        (row, i) => (
+          <tr key={i}>
+            {F.mapIndexed(
+              ({ display = x => x, hidden }, key) =>
+                !hidden && <td key={key}>{display(row[key], row)}</td>,
+              fields
+            )}
+          </tr>
+        ),
+        data
+      )}
+    </tbody>
+  </Table>
+)
+export default DataTable
+
+export let TruncatableDataTable = ({ data, limit = 5, ...props }) => {
+  let [show, setShow] = React.useState(false)
+  return (
+    <>
+      <DataTable data={show ? data : _.take(limit, data)} {...props} />
+      {data.length > 5 && (
+        <LinkButton onClick={() => setShow(x => !x)}>
+          {show ? 'Less' : 'More'}...
+        </LinkButton>
+      )}
+    </>
+  )
+}

--- a/src/stories/DataTable.stories.js
+++ b/src/stories/DataTable.stories.js
@@ -1,0 +1,16 @@
+import React from 'react'
+import DataTable from '../DataTable'
+import _ from 'lodash/fp'
+import F from 'futil'
+
+export default { title: 'DataTable', component: DataTable }
+
+let data = [
+  { user: 'barney', age: 36, active: true },
+  { user: 'fred', age: 40, active: false },
+  { user: 'pebbles', age: 1, active: true },
+]
+
+let fields = F.arrayToObject(_.identity, F.autoLabelOption, _.keys(data[0]))
+
+export let baseUsage = () => <DataTable fields={fields} data={data} />


### PR DESCRIPTION
**Changes**
- currently this PR just adds the DataTable component from our app and a thrown-together story for it

**Notes**
- now that our fancy paginated TableFooter lives in grey-vest, it'd be neat to have a table component that actually takes care of rendering all the table elements and just takes an API for data
- ideally this would replace a bunch of the current functionality of ResultTable in contexture-react, such that the contexture-react side becomes a wrapper to handle tree and node stuff (like with Pager and ResultPager)
- we should also refactor ExpandableTable while we're at it, and settle on one API to use between the two (or possibly just combine them)