### PR TITLE
docs docs docs

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -11,6 +11,11 @@ addDecorator(Story => (
   </>
 ))
 
+// DocsPage's propsSlot supplies the data for its Props component, and extractComponentDescription
+// does the same for the Description slot. This customization tells storybook to pull data from
+// `parameters.props` for props and `parameters.info` for the description, rather than from JSDoc.
+// We do it this way because Storybook's PropTypes/JSDoc parser doesn't work very well with most
+// of our components.
 addParameters({
   docs: {
     page: () => (

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,4 +1,7 @@
 import { configure, addDecorator } from '@storybook/react'
+import { addParameters } from '@storybook/client-api'
+import { DocsPage } from '@storybook/addon-docs/blocks'
+import F from 'futil'
 import Fonts from '../src/Fonts'
 import React from 'react'
 
@@ -8,6 +11,17 @@ addDecorator(Story => (
     <Story />
   </>
 ))
+
+addParameters({
+  docs: {
+    page: () => (
+      <DocsPage
+        propsSlot={({ parameters: { props = { rows: [] } } }) => props}
+      />
+    ),
+    extractComponentDescription: (target, { info }) => info,
+  },
+})
 
 configure(
   require.context(

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,7 +1,6 @@
 import { configure, addDecorator } from '@storybook/react'
 import { addParameters } from '@storybook/client-api'
 import { DocsPage } from '@storybook/addon-docs/blocks'
-import F from 'futil'
 import Fonts from '../src/Fonts'
 import React from 'react'
 

--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -44,6 +44,13 @@ Component props that control whitespace now take spacing values from GreyVest's 
 | Box        | `padding`, `paddingX`, `paddingY`, `p`, `px`, `py` | new in 3.0         |
 | Divider    | `margin`, `m`                                      | new in 3.0         |
 
+#### 3.0.0-alpha.13
+* Customize storybook config to take `props` and `info` from story definition instead of parsing component JSDocs
+* Add documentation for component variants and storybook's API (with our customizations)
+* Add a story for SpacedList
+* Add a demo story to compare spacing components (Flex, Grid, SpacedList)
+* Add prop information to SpacedList & Button stories
+
 #### 3.0.0-alpha.12
 * More styling improvements for a bunch of components (Select in particular)
 * Overhaul SpacedList:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grey-vest",
-  "version": "3.0.0-alpha.12",
+  "version": "3.0.0-alpha.13",
   "description": "GreyVest component library",
   "main": "dist/index.js",
   "scripts": {

--- a/src/FormField.js
+++ b/src/FormField.js
@@ -1,4 +1,5 @@
 import _ from 'lodash/fp'
+import { defaultProps } from 'recompose'
 import React from 'react'
 import Flex from './Flex'
 import GridItem from './GridItem'
@@ -17,6 +18,7 @@ import theme from './theme'
 let types = {
   date: DateInput,
   text: TextInput,
+  number: defaultProps({ type: 'number' })(TextInput),
   textarea: Textarea,
   checkboxList: CheckboxList,
   select: Select,

--- a/src/SpacedList.js
+++ b/src/SpacedList.js
@@ -15,8 +15,9 @@ let SpacedList = ({
       columnWidth,
       columnCount,
       columnGap: theme.space(columnGap),
+      '& > *': { breakInside: 'avoid-column' },
       // Targets every direct child with another direct child before it
-      '& > * + *': { marginTop: theme.space(gap), breakInside: 'avoid-column' },
+      '& > * + *': { marginTop: theme.space(gap) },
     }}
     {...props}
   >

--- a/src/docs/storybookAPI.stories.mdx
+++ b/src/docs/storybookAPI.stories.mdx
@@ -53,9 +53,9 @@ You can supply a description for the story with the `info` property. It takes on
 ```js
 {
   info:
-"
-GreyVest's `Button` features **five** component-level styling variants: `Primary`, `Secondary`, `Tertiary`, `Danger`, and `Ghost`. The variants are subcomponents of Button.
-"
+`
+GreyVest's Button component features five styling variants: **primary**, **secondary**, **tertiary**, **danger**, and **ghost**. The variants are subcomponents of Button (eg \`Button.Primary\`).
+`
 }
 ```
 

--- a/src/docs/storybookAPI.stories.mdx
+++ b/src/docs/storybookAPI.stories.mdx
@@ -73,12 +73,12 @@ A prop definition has the following shape (see Storybook's [PropDef](https://git
 
 ```js
 {
-    name,
-    required, // defaults to false
-    description,
-    type: { summary, detail },
-    defaultValue: { summary, detail },
-  }
+  name,
+  required, // defaults to false
+  description,
+  type: { summary, detail },
+  defaultValue: { summary, detail },
+}
 ```
 
 ### Example

--- a/src/docs/storybookAPI.stories.mdx
+++ b/src/docs/storybookAPI.stories.mdx
@@ -1,0 +1,112 @@
+import { Meta } from '@storybook/addon-docs/blocks'
+
+<Meta title="Developer Notes | Storybook API" />
+
+# Storybook API reference
+
+GreyVest's documentation is written using Storybook 5.2's [Docs addon](https://github.com/storybookjs/storybook/blob/next/addons/docs/docs/docspage.md) with stories in [CSF format](https://medium.com/storybookjs/component-story-format-66f4c32366df).
+
+CSF stories declare a configuration object as their default export. The API looks like this:
+
+```js
+export default {
+  title,
+  component,
+  decorators,
+  parameters: {
+    componentSubtitle,
+    info,
+    props
+  },
+}
+```
+
+### A note on customizations
+
+Storybook docs are supposed to automatically parse PropTypes and JSDocs into data for the description and props table, but this is not ideal for us for two reasons:
+
+1. Our widespread use of HOCs such as mobx-react's `observer` means that Storybook has trouble parsing metadata for a lot of our components (this will likely be ironed out as Storybook Docs matures, but we'd rather not wait for that to happen)
+2. We haven't historically used PropTypes and would have to add the data in some format to each of our components or stories anyway - and for documentation only, using PropTypes is less flexible than manually specifying the arguments to PropTable
+
+As a result, our storybook configuration is customized to pass the values from the `props` and `info` properties in `parameters` directly into Storybook's PropsTable and Description components, respectively.
+
+
+## Subtitle
+
+`componentSubtitle` is a built-in Storybook property for the subtitle of a DocsPage. It supports JSX expressions.
+
+### Example
+
+```jsx
+{
+  componentSubtitle: <>Button with <tt>large</tt> and <tt>compact</tt> variants</>
+}
+```
+
+
+## Description
+
+You can supply a description for the story with the `info` property. It takes only strings, but supports markdown formatting.
+
+### Example
+
+```js
+{
+  info:
+"
+GreyVest's `Button` features **five** component-level styling variants: `Primary`, `Secondary`, `Tertiary`, `Danger`, and `Ghost`. The variants are subcomponents of Button.
+"
+}
+```
+
+
+## Props
+
+The `props` property accepts an object with two keys, `rows` and `sections`. Only one of these is used; if `sections` has a value, it overrides `rows`.
+
+| Property | Value  |
+| --- | --- |
+| `rows` | an array of prop definitions |
+| `sections` | an object where each key is a section heading, and each value is an array of prop definitions |
+
+A prop definition has the following shape (see Storybook's [PropDef](https://github.com/storybookjs/storybook/blob/next/lib/components/src/blocks/PropsTable/PropDef.ts) type for reference):
+
+```js
+{
+    name,
+    required, // defaults to false
+    description,
+    type: { summary, detail },
+    defaultValue: { summary, detail },
+  }
+```
+
+### Example
+
+```js
+let flagDef = {
+  type: { summary: 'boolean' },
+  defaultValue: { summary: 'false' },
+}
+
+let props = {
+  sections: {
+    flags: [
+      { name: 'compact', ...flagDef },
+      { name: 'large', ...flagDef },
+    ],
+    other: [
+      {
+        name: 'onClick',
+        description: 'click handler for button',
+        type: { summary: 'function' }
+      }
+    ]
+  },
+}
+
+export default {
+  title: 'Button',
+  parameters: { docs: { props } },
+}
+```

--- a/src/docs/storybookAPI.stories.mdx
+++ b/src/docs/storybookAPI.stories.mdx
@@ -110,3 +110,20 @@ export default {
   parameters: { docs: { props } },
 }
 ```
+
+## Stories
+
+Stories in CSF are simply named exports. You can customize individual stories by adding properties to the story object; `story.name` controls the title of the story in the sidebar, and `story.parameters.docs.storyDescription` allows you to add a description that appears above that story in the DocsPage.
+
+```jsx
+export let secondary = () => <Button.Secondary>Click me</Button.Secondary>
+secondary.story = {
+  name: 'Secondary (default)',
+  parameters: {
+    docs: {
+      storyDescription:
+        'Since the secondary color variant is also the default styling for Button, it can be used with either `Button` or `Button.Secondary`.',
+    },
+  },
+}
+```

--- a/src/docs/variants.stories.mdx
+++ b/src/docs/variants.stories.mdx
@@ -1,0 +1,81 @@
+import { Meta } from '@storybook/addon-docs/blocks'
+
+<Meta title="Design System | Variants" />
+
+# Variants
+
+Several GreyVest components have multiple options for coloration, size, or other properties -- for example, each typography component has at least one alternate text size in addition to the default. 
+
+Our design system uses three different types of variants: component-level variants, subcomponent-level variants, and flag-level variants.
+
+## Component-level variants
+
+Component-level variants are completely separate components that are variations of each other or of a common parent.
+
+### Examples
+
+- The three typography components (`Text`, `Subtitle`, and `Title`) are essentially component-level variants.
+- The `Dropdown` component is a variant of the `Popover` component without any inner padding.
+
+## Subcomponent-level variants
+
+Subcomponents are components that are properties of another component, and can be accessed in JSX with dot notation, eg: 
+
+```jsx
+<Button.Primary>Click me</Button.Primary>
+```
+
+Subcomponent-level variants are technically completely separate components, but because they are properties of the main component, they don't need to be imported separately:
+
+```jsx
+import { Button } from 'grey-vest'
+
+<>
+  <Button>Cancel</Button>
+  <Button.Primary>Submit</Button.Primary>
+</>
+```
+
+### Examples
+
+| Component | Subcomponent-level variants | Differences |
+| --- | --- | --- |
+| Button | Primary, Secondary, Tertiary, Danger, Ghost | background and text colors |
+| Tabs | Transparent, Classic | TabsList styling |
+| Box | Popup, Modal | box-shadow styling |
+| Banner | Warning, Error | background color and icon |
+
+
+## Flag-level variants
+
+A flag-level variant is simply a boolean prop on a component. With React's [prop shorthand](https://reactjs.org/docs/jsx-in-depth.html#props-default-to-true), a flag prop can be set to true simply by passing its name:
+
+```jsx
+<Title>This is a normal-sized title</Title>
+
+<Title large>This is a large title</Title>
+```
+
+In contrast to component- and subcomponent-level variants, flag-level variants are *not* mutually exclusive. This is useful when a single component has multiple types of variations, such as Button's color and size variants. If the size variants were also represented with subcomponents, we'd need one subcomponent for each combination of color and size (eg `Button.PrimaryLarge`). But with flag variants, we can do this instead:
+
+```jsx
+<Button.Primary large>I am a large primary button</Button.Primary>
+```
+
+### Examples
+
+| Component | Flag-level variants | Differences |
+| --- | --- | --- |
+| Button | `compact`, `large` | padding and text size |
+| Text | `small`, `extraSmall` | font size and line height |
+| Subtitle | `large` | font size and line height |
+| Title | `large`, `small` | font size and line height |
+| ErrorList | `block` | uses block styling |
+
+In addition to these, there are some common flags in GreyVest that are supported by multiple components, and could be considered to be variants:
+
+| Flag | Supported components | Purpose |
+| --- | --- | --- |
+| `native` | DateInput, RadioList, Select | Use native form elements instead of JS implementations |
+| `active` | Button, PagerItem, PickerItem | Update styling to convey that the item is currently active |
+| `disabled` | Button, Checkbox, DropdownItem, PagerItem, PickerItem | Disable input and events on the component, and update styling to convey that the item is disabled |

--- a/src/stories/Button.stories.js
+++ b/src/stories/Button.stories.js
@@ -13,7 +13,7 @@ let props = {
         type: { summary: 'function' },
         defaultValue: { summary: '() => {}' },
       },
-      { ...asProp, defaultValue: { summary: `'button'` }},
+      { ...asProp, defaultValue: { summary: `'button'` } },
     ],
   },
 }
@@ -67,7 +67,12 @@ export let secondary = () => (
 )
 secondary.story = {
   name: 'Secondary (default)',
-  parameters: { docs: { storyDescription: 'hello' } },
+  parameters: {
+    docs: {
+      storyDescription:
+        'Since the secondary color variant is also the default styling for Button, it can be used with either `Button` or `Button.Secondary`.',
+    },
+  },
 }
 
 export let tertiary = () => (

--- a/src/stories/Button.stories.js
+++ b/src/stories/Button.stories.js
@@ -1,8 +1,31 @@
 import React from 'react'
 import { action } from '@storybook/addon-actions'
 import { Button, Grid } from '..'
+import { flag, asProp } from './commonProps'
 
-export default { title: 'Button', component: Button }
+let props = {
+  sections: {
+    'size flags': [{ name: 'compact', ...flag }, { name: 'large', ...flag }],
+    other: [
+      {
+        name: 'onClick',
+        description: 'Click handler for button',
+        type: { summary: 'function' },
+        defaultValue: { summary: '() => {}' },
+      },
+      { ...asProp, defaultValue: { summary: `'button'` }},
+    ],
+  },
+}
+
+export default {
+  title: 'Button',
+  component: Button,
+  parameters: {
+    componentSubtitle: 'Features five color variations and three sizes',
+    props,
+  },
+}
 
 let clickAction = () => action('clicked')()
 
@@ -42,7 +65,10 @@ export let secondary = () => (
     <Button.Secondary compact>Compact</Button.Secondary>
   </Container>
 )
-secondary.story = { name: 'Secondary (default)' }
+secondary.story = {
+  name: 'Secondary (default)',
+  parameters: { docs: { storyDescription: 'hello' } },
+}
 
 export let tertiary = () => (
   <Container>

--- a/src/stories/Button.stories.js
+++ b/src/stories/Button.stories.js
@@ -22,8 +22,12 @@ export default {
   title: 'Button',
   component: Button,
   parameters: {
-    componentSubtitle: 'Features five color variations and three sizes',
+    componentSubtitle: 'With five color variations and three sizes',
     props,
+    info:
+`
+GreyVest's Button component features five styling variants: **primary**, **secondary**, **tertiary**, **danger**, and **ghost**. The variants are subcomponents of Button (eg \`Button.Primary\`).
+`
   },
 }
 

--- a/src/stories/SpacedList.stories.js
+++ b/src/stories/SpacedList.stories.js
@@ -4,17 +4,47 @@ import _ from 'lodash/fp'
 import { loremIpsum } from 'lorem-ipsum'
 import { Divider, Flex, SpacedList, FormField } from '..'
 import { useLensObject } from '../utils'
+import { spacingValue, cssValue } from './commonProps'
+import theme from '../theme'
+
+let props = {
+  rows: [
+    {
+      ...spacingValue,
+      name: 'gap',
+      description:
+        'vertical spacing between each element in the list',
+    },
+    {
+      ...spacingValue,
+      name: 'columnGap',
+      description: 'horizontal spacing between columns',
+    },
+    {
+      name: 'columnCount',
+      description: '_maximum_ number of columns',
+      type: { summary: 'number' },
+      defaultValue: { summary: 1 },
+    },
+    {
+      ...cssValue,
+      name: 'columnWidth',
+      description: '_minimum_ width of each column',
+      defaultValue: { summary: theme.widths.xs },
+    },
+  ],
+}
 
 export default {
   title: 'SpacedList',
   component: SpacedList,
-  parameters: { props: { rows: [] } },
+  parameters: { props },
 }
 
 let content = _.times(loremIpsum, 30)
 
 let makeFields = F.mapIndexed((lens, key) => (
-  <FormField label={key} type="text" {...F.domLens.value(lens)} />
+  <FormField label={key} type="number" {...F.domLens.value(lens)} />
 ))
 
 export let story = () => {
@@ -32,7 +62,7 @@ export let story = () => {
         {..._.mapValues(
           _.flow(
             F.view,
-            _.toInteger
+            _.toNumber
           ),
           state
         )}

--- a/src/stories/SpacedList.stories.js
+++ b/src/stories/SpacedList.stories.js
@@ -1,0 +1,51 @@
+import React from 'react'
+import F from 'futil'
+import _ from 'lodash/fp'
+import { loremIpsum } from 'lorem-ipsum'
+import { Divider, Flex, SpacedList, FormField } from '..'
+import { useLensObject } from '../utils'
+
+export default {
+  title: 'SpacedList',
+  component: SpacedList,
+  parameters: { props: { rows: [] } },
+}
+
+let content = _.times(loremIpsum, 30)
+
+let makeFields = F.mapIndexed((lens, key) => (
+  <FormField label={key} type="text" {...F.domLens.value(lens)} />
+))
+
+export let story = () => {
+  let state = useLensObject({
+    gap: 1,
+    columnGap: 2,
+    columnCount: 5,
+    columnWidth: 300,
+  })
+  return (
+    <>
+      <Flex gap={1}>{makeFields(state)}</Flex>
+      <Divider m={2} />
+      <SpacedList
+        {..._.mapValues(
+          _.flow(
+            F.view,
+            _.toInteger
+          ),
+          state
+        )}
+      >
+        {F.mapIndexed(
+          (x, i) => (
+            <div style={{ background: 'cyan' }}>
+              {i + 1}. {x}
+            </div>
+          ),
+          content
+        )}
+      </SpacedList>
+    </>
+  )
+}

--- a/src/stories/SpacingDemo.stories.js
+++ b/src/stories/SpacingDemo.stories.js
@@ -1,0 +1,85 @@
+import React from 'react'
+import F from 'futil'
+import _ from 'lodash/fp'
+import { loremIpsum } from 'lorem-ipsum'
+import { Grid, Divider, Flex, SpacedList, Select, Dynamic } from '..'
+
+export default { title: 'Demos | Spacing' }
+
+let inlineContent = F.mapIndexed(
+  (x, i) => (
+    <span key={i} style={{ backgroundColor: 'cyan' }}>
+      {x}
+    </span>
+  ),
+  _.times(loremIpsum, 8)
+)
+
+export let withInlineContent = () => {
+  let components = { Flex, Grid, SpacedList }
+  let component = React.useState('Flex')
+  return (
+    <>
+      <Select
+        options={F.autoLabelOptions(_.keys(components))}
+        {...F.domLens.value(component)}
+      />
+      <Divider m={2} />
+      <Dynamic component={components[F.view(component)]} gap={1}>
+        {inlineContent}
+      </Dynamic>
+    </>
+  )
+}
+
+let columnContent = F.mapIndexed(
+  (height, i) => (
+    <Flex
+      alignItems="center"
+      justifyContent="center"
+      key={i}
+      style={{ border: '2px solid cyan', background: 'yellow', fontSize: 20, height }}
+    >
+      {i}
+    </Flex>
+  ),
+  _.times(() => _.random(1, 10) * 20, 7)
+)
+
+export let columns = () => {
+  let components = { Grid, SpacedList }
+  let component = React.useState('Grid')
+  return (
+    <>
+      <Select
+        options={F.autoLabelOptions(_.keys(components))}
+        {...F.domLens.value(component)}
+      />
+      <Divider m={2} />
+      <Dynamic
+        component={components[F.view(component)]}
+        // both Grid and SpacedList
+        gap={1}
+        // Grid property
+        columns={2}
+        // SpacedList properties
+        columnCount={2}
+        columnGap={2}
+      >
+        {columnContent}
+      </Dynamic>
+    </>
+  )
+}
+columns.story = {
+  parameters: {
+    docs: {
+      storyDescription: 
+`
+This story demonstrates the differences in the way the \`Grid\` and \`SpacedList\` components handle columns.
+
+
+`
+    },
+  },
+}

--- a/src/stories/SpacingDemo.stories.js
+++ b/src/stories/SpacingDemo.stories.js
@@ -76,9 +76,14 @@ columns.story = {
     docs: {
       storyDescription: 
 `
-This story demonstrates the differences in the way the \`Grid\` and \`SpacedList\` components handle columns.
+This story demonstrates the differences in the way GreyVest's \`Grid\` and \`SpacedList\` components handle columns.
 
-
+| | Grid | SpacedList |
+| --- | --- | --- |
+| **rows** | has rows | does not have rows |
+| **gap API** | \`columnGap\` and \`rowGap\` control the gap between columns and rows respectively; \`gap\` is a shorthand to set both | \`gap\` controls the gap between elements, and \`columnGap\` controls the gap between columns |
+| **content ordering** | Left-to-right, then top-to-bottom | Top-to-bottom, then left-to-right |
+| **placement** | Each child element is placed inside a grid square, which is sized according to the largest element in the row | Content flows vertically within each column, then overflows to the next |
 `
     },
   },

--- a/src/stories/commonProps.js
+++ b/src/stories/commonProps.js
@@ -1,0 +1,15 @@
+export let flag = {
+  type: { summary: 'boolean' },
+  defaultValue: { summary: 'false' },
+}
+
+export let asProp = {
+  name: 'as',
+  description: 'Accepts a React component or a string representing a DOM element',
+  type: { summary: 'Component | string' },
+}
+
+export let disabled = {
+  name: 'disabled',
+  ...flag
+}

--- a/src/stories/commonProps.js
+++ b/src/stories/commonProps.js
@@ -5,11 +5,30 @@ export let flag = {
 
 export let asProp = {
   name: 'as',
-  description: 'Accepts a React component or a string representing a DOM element',
+  description:
+    'Accepts a React component or a string representing a DOM element',
   type: { summary: 'Component | string' },
 }
 
 export let disabled = {
   name: 'disabled',
-  ...flag
+  ...flag,
+}
+
+export let spacingValue = {
+  type: { summary: 'SpacingValue', detail: `
+number | string
+/* A spacing value can be either a number, which is multiplied by 8 to obtain
+pixel measurements, or a string alias ("xs", "sm", "md", or "lg"). You can
+also specify arbitrary values by passing them as strings (e.g. "200px"). */
+` },
+  defaultValue: { summary: 0 },
+}
+
+export let cssValue = {
+  type: { summary: 'CSSValue', detail: `
+number | string
+/* If number, is converted to pixel units in CSS.
+If string, units should be specified. */
+` }
 }


### PR DESCRIPTION
* Customize storybook config to take `props` and `info` from story definition instead of parsing component JSDocs
* Add documentation for component variants and storybook's API (with our customizations)
* Add a story for SpacedList
* add a demo story to compare spacing components (Flex, Grid, SpacedList)
* Add prop information to SpacedList & Button stories