### PR TITLE
Feature/gaps

### DIFF
--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -109,6 +109,10 @@ Component props that control whitespace now take the following spacing aliases f
 
 <hr />
 
+#### 3.0.0-alpha.21
+
+- Don't convert numeric values on spacing props to design system values
+
 #### 3.0.0-alpha.20
 
 - Remove some unused imports (react-outside-click-handler, moment)

--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -55,6 +55,7 @@ A small number of components have been 🚨 **REMOVED** 🚨(or renamed):
   - Both now support the `disabled` property on options (to mark that option as disabled)
   - Both components now also support ColumnList props (`gap`, `columnCount`, `columnWidth`, and `columnGap`)
 - New props on **DropdownItem**: `disabled`, `truncate`, and `icon` (same as the Icon component's `icon` prop)
+- Added a `gap` prop to **Flex** to control spacing between child elements using CSS selectors and margins. (Note that if `wrap` is set, this adds a `div` wrapper around the Flex component)
 - Changes to **Icon**:
   - New variants: `small` and `large`
   - 🚨 Removed support for contexture-react's custom icon keys (eg 'SortAscending', 'TableColumnMenu', etc) - the `icon` prop now only supports [material icon keys](https://material.io/resources/icons/) or components
@@ -77,35 +78,34 @@ A small number of components have been 🚨 **REMOVED** 🚨(or renamed):
 
 ### Spacing props
 
-Component props that control whitespace now take spacing values from GreyVest's design system instead of pixel measurements. These props can take either a number which is multiplied by `8` to produce a size in pixels, or one of the following string aliases:
+Component props that control whitespace now take the following spacing aliases from GreyVest's design system in addition to regular values:
 
 - `xs`: 4px
 - `sm`: 8px
 - `md`: 16px
 - `lg`: 32px
 
-| Component  | Prop(s)                           | Status            |
-| ---------- | --------------------------------- | ----------------- |
-| Grid       | `gap`, `rowGap`, `columnGap`      | 🚨**BREAKING** 🚨 |
-| Flex       | `gap`                             | new in 3.0        |
-| ColumnList | `gap`, `columnGap`                | new in 3.0        |
-| Box        | `padding`, `paddingX`, `paddingY` | new in 3.0        |
-| Divider    | `margin`                          | new in 3.0        |
+| Component  | Prop(s)                           | New? |
+| ---------- | --------------------------------- | ---- |
+| Grid       | `gap`, `rowGap`, `columnGap`      | no   |
+| Flex       | `gap`                             | yes  |
+| ColumnList | `gap`, `columnGap`                | yes  |
+| Box        | `padding`, `paddingX`, `paddingY` | yes  |
+| Divider    | `margin`                          | yes  |
 
 ## Migration Guide
 
-1. For all `gap` props on **Box** components that use numbers, divide the value by 8
-2. Convert all `onClose` props on **Popover** components to `onChange` (the callback receives the open/closed state of the popover as its argument)
-3. Replace all references to...
+1. Convert all `onClose` props on **Popover** components to `onChange` (the callback receives the open/closed state of the popover as its argument)
+2. Replace all references to...
    - **TabList** with **TabsList**
    - **SpacedList** with **ColumnList**
    - **TextButton** with **IconButton**
    - **ErrorList** with **ErrorText**
    - **LinkButton** with **LinkText**
-4. Remove all references to the **ButtonRadio**, **BarChart**, **ExpandableTagsInput**, and **Style** components
-5. Remove any CSS targeting `gv-` classNames
-6. Update any **Icon** components using contexture-react icon keys to use a material icon key (or a custom component) instead
-7. Import and use the design system constants from GreyVest's theme file, rather than hard-coding spacing or color values
+3. Remove all references to the **ButtonRadio**, **BarChart**, **ExpandableTagsInput**, and **Style** components
+4. Remove any CSS targeting `gv-` classNames
+5. Update any **Icon** components using contexture-react icon keys to use a material icon key (or a custom component) instead
+6. Import and use the design system constants from GreyVest's theme file, rather than hard-coding spacing or color values
 
 <hr />
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "grey-vest",
-  "version": "3.0.0-alpha.20",
+  "version": "3.0.0-alpha.21",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grey-vest",
-  "version": "3.0.0-alpha.20",
+  "version": "3.0.0-alpha.21",
   "description": "GreyVest component library",
   "main": "dist/index.js",
   "scripts": {

--- a/src/Box.js
+++ b/src/Box.js
@@ -8,7 +8,7 @@ import { getVariants, coalesce } from './utils'
 import theme from './theme'
 
 let Box = (
-  { as: As = 'div', padding = 2, paddingX, paddingY, ...props },
+  { as: As = 'div', padding = 'md', paddingX, paddingY, ...props },
   ref
 ) => (
   <As
@@ -17,11 +17,11 @@ let Box = (
       backgroundColor: theme.colors.backgrounds[0],
       boxShadow: getVariants(props, theme.boxShadows, 'normal'),
       ..._.flow(
-        F.flowMap(coalesce, theme.space),
+        F.flowMap(coalesce, F.aliasIn(theme.spaces)),
         _.apply(pad)
       )([
-        [paddingY, _.head(padding), padding],
-        [paddingX, _.last(padding), padding],
+        [paddingY, _.head(_.castArray(padding))],
+        [paddingX, _.last(_.castArray(padding))],
       ]),
     }}
     {...{ ref, ...props }}

--- a/src/CheckboxList.js
+++ b/src/CheckboxList.js
@@ -10,7 +10,7 @@ import { Text } from './Typography'
 import theme from './theme'
 
 let CheckboxList = ({ options, value, onChange, ...props }) => (
-  <ColumnList gap={1} {...props}>
+  <ColumnList gap="sm" {...props}>
     {_.map(
       option => (
         <Flex

--- a/src/ColumnList.js
+++ b/src/ColumnList.js
@@ -1,5 +1,6 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/core'
+import F from 'futil'
 import theme from './theme'
 
 let ColumnList = ({
@@ -14,10 +15,10 @@ let ColumnList = ({
     css={{
       columnWidth,
       columnCount,
-      columnGap: theme.space(columnGap),
+      columnGap: F.alias(columnGap, theme.spaces),
       '& > *': { breakInside: 'avoid-column' },
       // Targets every direct child with another direct child before it
-      '& > * + *': { marginTop: theme.space(gap) },
+      '& > * + *': { marginTop: F.alias(gap, theme.spaces) },
     }}
     {...props}
   >

--- a/src/Divider.js
+++ b/src/Divider.js
@@ -1,11 +1,13 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/core'
+import F from 'futil'
+import { margin as getMargin } from 'polished'
 import theme from './theme'
 import GridItem from './GridItem'
 
-let Divider = ({ vertical = false, margin = 1, ...props }) => (
+let Divider = ({ vertical = false, margin = 'sm', ...props }) => (
   <GridItem
-  place={vertical ? "stretch center" : "center stretch"}
+    place={vertical ? 'stretch center' : 'center stretch'}
     css={[
       {
         backgroundColor: theme.colors.neutrals[0],
@@ -13,13 +15,11 @@ let Divider = ({ vertical = false, margin = 1, ...props }) => (
       vertical
         ? {
             width: 1,
-            marginLeft: theme.space(margin),
-            marginRight: theme.space(margin),
+            ...getMargin(0, F.alias(margin, theme.spaces)),
           }
         : {
             height: 1,
-            marginTop: theme.space(margin),
-            marginBottom: theme.space(margin),
+            ...getMargin(F.alias(margin, theme.spaces), 0),
           },
     ]}
     {...props}

--- a/src/Flex.js
+++ b/src/Flex.js
@@ -1,6 +1,7 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/core'
 import { forwardRef } from 'react'
+import F from 'futil'
 import theme from './theme'
 
 let Flex = ({
@@ -15,7 +16,7 @@ let Flex = ({
   gap = 0,
   ...props
 }, ref) => {
-  let m = theme.space(gap)
+  let m = F.alias(gap, theme.spaces)
   let flexStyle = [
     {
       display: `${inline ? 'inline-' : ''}flex`,

--- a/src/Form.js
+++ b/src/Form.js
@@ -4,7 +4,7 @@ import { Grid, Flex, Title, Text } from '.'
 import theme from './theme'
 
 export let Form = props => (
-  <Flex css={{ width: theme.widths.lg }} column gap={2} {...props} />
+  <Flex css={{ width: theme.widths.lg }} column gap="md" {...props} />
 )
 
 export let FormHeader = ({ title, description, ...props }) => (

--- a/src/Form.js
+++ b/src/Form.js
@@ -21,5 +21,5 @@ export let FormHeader = ({ title, description, ...props }) => (
 export let FormContent = props => <Grid rowGap={2} columnGap={3} {...props} />
 
 export let FormFooter = props => (
-  <Flex gap={1} css={{ paddingTop: theme.space(1) }} {...props} />
+  <Flex gap="sm" css={{ paddingTop: theme.space(1) }} {...props} />
 )

--- a/src/Grid.js
+++ b/src/Grid.js
@@ -26,8 +26,8 @@ let Grid = styled.div(
     gridTemplateColumns: repeatNumber(columns),
     gridTemplateRows: repeatNumber(rows),
     gridTemplateAreas: formatAreas(areas),
-    gridRowGap: theme.space(rowGap || gap),
-    gridColumnGap: theme.space(columnGap || gap),
+    gridRowGap: F.alias(rowGap || gap, theme.spaces),
+    gridColumnGap: F.alias(columnGap || gap, theme.spaces),
     placeContent,
     placeItems,
   })

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -70,7 +70,7 @@ export let ModalFooter = ({ children }) => (
     alignItems="center"
     justifyContent="flex-end"
     css={{ marginTop: theme.space(3) }}
-    gap={1}
+    gap="sm"
   >
     {children}
   </Flex>

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -35,7 +35,7 @@ export let Modal = _.flow(
       >
         <Box
           modal
-          padding={3}
+          padding={theme.space(3)}
           onClick={e => e.stopPropagation()}
           css={{ minWidth: 400, maxWidth: 600, position: 'relative' }}
           {...props}

--- a/src/Popover.js
+++ b/src/Popover.js
@@ -19,7 +19,7 @@ let PopupBox = forwardRef((props, ref) => (
       minWidth: theme.widths.popup.min,
       maxWidth: theme.widths.popup.max,
     }}
-    padding={[1, 2]}
+    padding={['sm', 'md']}
     ref={ref}
     {...props}
   />

--- a/src/RadioList.js
+++ b/src/RadioList.js
@@ -46,7 +46,7 @@ let RadioButton = ({ native, option, value, onChange, ...props }) => (
 )
 
 let RadioList = ({ options, value, onChange, native = false, ...props }) => (
-  <ColumnList gap={1} {...props}>
+  <ColumnList gap="sm" {...props}>
     {_.map(
       option => (
         <Flex

--- a/src/TagsInput.js
+++ b/src/TagsInput.js
@@ -148,7 +148,7 @@ let TagsInput = ({
       css={theme.inputStyle}
       alignItems="stretch"
       justifyContent="center"
-      gap={1}
+      gap="sm"
       {...props}
     >
       {flipped && input}

--- a/src/stories/Awaiter.stories.js
+++ b/src/stories/Awaiter.stories.js
@@ -12,7 +12,7 @@ export let story = () => {
       reject = _reject
     })
   return (
-    <Grid gap={1} columns={2}>
+    <Grid gap="sm" columns={2}>
       <GridItem as={Box} width={2}>
         <Awaiter promiseFn={p}>{x => <div>{x}</div>}</Awaiter>
       </GridItem>

--- a/src/stories/Box.stories.js
+++ b/src/stories/Box.stories.js
@@ -47,7 +47,7 @@ export let controlledPadding = () => {
     </Box>
   )
   return (
-    <Grid gap={2}>
+    <Grid gap="md">
       <GreyPaddingBox paddingX={4} paddingY="sm">
         {theme.space(4)}px by {theme.space('sm')}px padding
       </GreyPaddingBox>

--- a/src/stories/Box.stories.js
+++ b/src/stories/Box.stories.js
@@ -43,30 +43,32 @@ export let popupBox = () => (
 export let controlledPadding = () => {
   let GreyPaddingBox = ({ children, ...props }) => (
     <Box style={{ background: 'lightgrey' }} {...props}>
-      <Text as="div" style={{ background: 'white' }}>{children}</Text>
+      <Text as="div" style={{ background: 'white' }}>
+        {children}
+      </Text>
     </Box>
   )
   return (
     <Grid gap="md">
-      <GreyPaddingBox paddingX={4} paddingY="sm">
-        {theme.space(4)}px by {theme.space('sm')}px padding
+      <GreyPaddingBox paddingX="lg" paddingY="sm">
+        {theme.space('lg')}px by {theme.space('sm')}px padding
       </GreyPaddingBox>
-      <GreyPaddingBox paddingX={1} paddingY="lg">
-        {theme.space(1)}px by {theme.spaces.lg}px padding
+      <GreyPaddingBox padding="sm" paddingY="lg">
+        {theme.spaces.sm}px by {theme.spaces.lg}px padding
       </GreyPaddingBox>
-      <GreyPaddingBox padding={[0.5, 0.5]}>
-        {theme.space(0.5)}px by {theme.space(0.5)}px padding
+      <GreyPaddingBox padding={['xs', 'xs']}>
+        {theme.space(0.5)}px by {theme.spaces.xs}px padding
       </GreyPaddingBox>
-      <GreyPaddingBox paddingX={0} padding={2}>
-        {theme.space(0)}px by {theme.space(2)}px padding
+      <GreyPaddingBox paddingX={0} padding={20}>
+        0px by 20px padding
       </GreyPaddingBox>
       {_.map(
-        padding => (
-          <GreyPaddingBox padding={padding}>
-            {theme.space(padding)}px padding
+        p => (
+          <GreyPaddingBox padding={p} key={p}>
+            {theme.space(p)}px padding
           </GreyPaddingBox>
         ),
-        _.range(0, 5)
+        ['xs', 'sm', 'md', 'lg']
       )}
     </Grid>
   )

--- a/src/stories/Button.stories.js
+++ b/src/stories/Button.stories.js
@@ -36,7 +36,7 @@ let clickAction = () => action('clicked')()
 
 let Container = ({ cols = 3, ...props }) => (
   <Grid
-    gap={2}
+    gap="md"
     columns={`repeat(${cols}, auto)`}
     placeItems="baseline"
     {...props}

--- a/src/stories/Button.stories.js
+++ b/src/stories/Button.stories.js
@@ -144,7 +144,7 @@ export let disabled = () => (
 
 export let withIcon = () => {
   let IconDemo = props => (
-    <Flex inline column gap={1} alignItems="flex-start">
+    <Flex inline column gap="sm" alignItems="flex-start">
       <Button {...props} icon="keyboard_arrow_down">
         Dropdown
       </Button>

--- a/src/stories/ButtonGroup.stories.js
+++ b/src/stories/ButtonGroup.stories.js
@@ -14,7 +14,7 @@ export let story = () => {
       _.times(lipsum, 4)
     )
   return (
-    <Grid inline gap={2}>
+    <Grid inline gap="md">
       <ButtonGroup>{listButtons()}</ButtonGroup>
       <ButtonGroup>{listButtons('primary')}</ButtonGroup>
       <ButtonGroup>{listButtons('secondary')}</ButtonGroup>

--- a/src/stories/CheckboxList.stories.js
+++ b/src/stories/CheckboxList.stories.js
@@ -11,7 +11,7 @@ let options = optionsFromArray(_.times(lipsum, 5))
 export let story = () => {
   let values = React.useState([0, 1])
   return (
-    <Grid gap={1}>
+    <Grid gap="sm">
       <div>
         Selected: <b>[{_.join(', ', F.view(values))}]</b>
       </div>
@@ -29,7 +29,7 @@ export let story = () => {
 export let columns = () => {
   let values = React.useState()
   return (
-    <Grid gap={1}>
+    <Grid gap="sm">
       <div>
         Selected: <b>[{_.join(', ', F.view(values))}]</b>
       </div>
@@ -53,7 +53,7 @@ columns.story = {
 export let disabled = () => {
   let values = React.useState([0, 1])
   return (
-    <Grid gap={1}>
+    <Grid gap="sm">
       <div>
         Selected: <b>[{_.join(', ', F.view(values))}]</b>
       </div>

--- a/src/stories/Colors.stories.js
+++ b/src/stories/Colors.stories.js
@@ -36,7 +36,7 @@ let SwatchSet = ({ title, colors }) => (
 )
 
 export let story = () => (
-  <Flex wrap gap={4} justifyContent="space-around">
+  <Flex wrap gap="lg" justifyContent="space-around">
     <SwatchSet colors={colors.primary} title="primary" />
     <SwatchSet colors={colors.secondary} title="secondary" />
     <SwatchSet colors={colors.text} title="text" />

--- a/src/stories/ColumnList.stories.js
+++ b/src/stories/ColumnList.stories.js
@@ -56,7 +56,7 @@ export let story = () => {
   })
   return (
     <>
-      <Flex gap={1}>{makeFields(state)}</Flex>
+      <Flex gap="sm">{makeFields(state)}</Flex>
       <Divider margin={2} />
       <ColumnList
         {..._.mapValues(

--- a/src/stories/ColumnList.stories.js
+++ b/src/stories/ColumnList.stories.js
@@ -57,7 +57,7 @@ export let story = () => {
   return (
     <>
       <Flex gap="sm">{makeFields(state)}</Flex>
-      <Divider margin={2} />
+      <Divider margin="md" />
       <ColumnList
         {..._.mapValues(
           _.flow(

--- a/src/stories/CommandButton.stories.js
+++ b/src/stories/CommandButton.stories.js
@@ -15,7 +15,7 @@ export let story = () => {
       })
   )
   return (
-    <Grid gap={1} columns={2}>
+    <Grid gap="sm" columns={2}>
       <GridItem style={{ textAlign: 'center' }} as={Box} width={2}>
         <CommandButton command={command} icon="access_time">
           Async thing

--- a/src/stories/DateInput.stories.js
+++ b/src/stories/DateInput.stories.js
@@ -8,7 +8,7 @@ export default { title: 'DateInput', component: DateInput }
 export let baseStory = () => {
   let [date, setDate] = React.useState(new Date('2019-12-31'))
   return (
-    <Grid gap={2} placeItems="start">
+    <Grid gap="md" placeItems="start">
       <Text>Selected: {date.toUTCString()}</Text>
       <DateInput
         value={date}
@@ -24,7 +24,7 @@ export let baseStory = () => {
 export let native = () => {
   let [date, setDate] = React.useState(new Date('2019-12-31'))
   return (
-    <Grid gap={2} placeItems="start">
+    <Grid gap="md" placeItems="start">
       <Text>Selected: {date.toUTCString()}</Text>
       <DateInput
         native

--- a/src/stories/DateTimeInput.stories.js
+++ b/src/stories/DateTimeInput.stories.js
@@ -8,7 +8,7 @@ export default { title: 'DateTimeInput', component: DateTimeInput }
 export let baseStory = () => {
   let [date, setDate] = React.useState(new Date('2019-12-31T05:00Z'))
   return (
-    <Grid gap={2} placeItems="start">
+    <Grid gap="md" placeItems="start">
       <Text>Selected: {date.toString()}</Text>
       <DateTimeInput
         value={date}
@@ -24,7 +24,7 @@ export let baseStory = () => {
 export let native = () => {
   let [date, setDate] = React.useState(new Date('2019-12-31T05:00Z'))
   return (
-    <Grid gap={2} placeItems="start">
+    <Grid gap="md" placeItems="start">
       <Text>Selected: {date.toString()}</Text>
       <DateTimeInput
         native

--- a/src/stories/Dialog.stories.js
+++ b/src/stories/Dialog.stories.js
@@ -41,7 +41,7 @@ let props = {
 export default { title: 'Dialog', component: Dialog, parameters: { props } }
 
 let Center = props => (
-  <Flex gap={2} justifyContent="space-around" alignItems="center" {...props} />
+  <Flex gap="md" justifyContent="space-around" alignItems="center" {...props} />
 )
 
 export let usage = () => (

--- a/src/stories/Divider.stories.js
+++ b/src/stories/Divider.stories.js
@@ -1,5 +1,6 @@
 import React from 'react'
-import { Divider, Text, Flex, Grid } from '..'
+import _ from 'lodash/fp'
+import { Divider, Text, Flex, Grid, Box } from '..'
 
 export default { title: 'Divider', component: Divider }
 
@@ -29,4 +30,17 @@ export let withGrid = () => (
     <Divider vertical />
     <Text>toes</Text>
   </Grid>
+)
+
+export let controlledMargin = () => (
+  <Flex column gap="md">
+    {_.map(
+      m => (
+        <Box padding={0}>
+          <Divider margin={m} />
+        </Box>
+      ),
+      ['xs,', 'sm', 'md', 'lg']
+    )}
+  </Flex>
 )

--- a/src/stories/Dropdown.stories.js
+++ b/src/stories/Dropdown.stories.js
@@ -6,7 +6,7 @@ import { lipsum } from './utils'
 export default { title: 'Dropdown', component: Dropdown }
 
 let Center = props => (
-  <Flex gap={2} justifyContent="space-around" alignItems="center" {...props} />
+  <Flex gap="md" justifyContent="space-around" alignItems="center" {...props} />
 )
 
 let generateDropdownItems = _.times(() => (

--- a/src/stories/Flex.stories.js
+++ b/src/stories/Flex.stories.js
@@ -33,7 +33,7 @@ export let noChildren = () => (
 )
 
 export let gap = () => (
-  <Flex gap={2} style={{ backgroundColor: 'yellow' }}>
+  <Flex gap="md" style={{ backgroundColor: 'yellow' }}>
     {_.times(
       () => (
         <div
@@ -50,7 +50,7 @@ export let gap = () => (
 )
 
 export let wrappedGap = () => (
-  <Flex wrap gap={2} style={{ backgroundColor: 'yellow' }}>
+  <Flex wrap gap="md" style={{ backgroundColor: 'yellow' }}>
     {_.times(
       () => (
         <div
@@ -68,7 +68,7 @@ export let wrappedGap = () => (
 )
 
 export let columnGap = () => (
-  <Flex inline column gap={2} style={{ backgroundColor: 'yellow' }}>
+  <Flex inline column gap="md" style={{ backgroundColor: 'yellow' }}>
     {_.times(
       () => (
         <div

--- a/src/stories/Grid.stories.js
+++ b/src/stories/Grid.stories.js
@@ -71,7 +71,7 @@ export let gridItemPositioning = () => (
 )
 
 export let rowsColumnsShorthand = () => (
-  <Grid columns={5} gap={1}>
+  <Grid columns={5} gap="sm">
     {_.times(
       n => (
         <div style={{ border: '2px solid black' }}>{n}</div>

--- a/src/stories/Grid.stories.js
+++ b/src/stories/Grid.stories.js
@@ -12,7 +12,7 @@ export default { title: 'Grid', component: Grid }
 export let grailDemo = () => (
   <>
     <Grid
-      gap={3}
+      gap="md"
       areas={[
         'header header header',
         'left main right',

--- a/src/stories/RadioList.stories.js
+++ b/src/stories/RadioList.stories.js
@@ -12,7 +12,7 @@ let shortOptions = optionsFromArray(_.times(() => lipsum(1, 'words'), 30))
 export let baseStory = () => {
   let value = React.useState(0)
   return (
-    <Grid gap={1}>
+    <Grid gap="sm">
       <div>
         Selected: <b>{F.view(value)}</b>
       </div>
@@ -30,7 +30,7 @@ export let baseStory = () => {
 export let native = () => {
   let value = React.useState(0)
   return (
-    <Grid gap={1}>
+    <Grid gap="sm">
       <div>
         Selected: <b>{F.view(value)}</b>
       </div>
@@ -49,7 +49,7 @@ export let native = () => {
 export let columns = () => {
   let value = React.useState()
   return (
-    <Grid gap={1}>
+    <Grid gap="sm">
       <div>
         Selected: <b>{F.view(value)}</b>
       </div>
@@ -73,7 +73,7 @@ columns.story = {
 export let disabled = () => {
   let value = React.useState(0)
   return (
-    <Grid gap={1}>
+    <Grid gap="sm">
       <div>
         Selected: <b>{F.view(value)}</b>
       </div>

--- a/src/stories/Select.stories.js
+++ b/src/stories/Select.stories.js
@@ -6,10 +6,19 @@ import { lipsum, optionsFromArray } from './utils'
 
 let props = {
   rows: [
-    { name: 'value'},
-    { name: 'options', type: { summary: 'Array<{ label: string, value: any, disabled: boolean }>'} },
-    { name: 'onChange', type: { summary: '(value: any) => any' }, description: "Called with the value of the selected option"}
-  ]
+    { name: 'value' },
+    {
+      name: 'options',
+      type: {
+        summary: 'Array<{ label: string, value: any, disabled: boolean }>',
+      },
+    },
+    {
+      name: 'onChange',
+      type: { summary: '(value: any) => any' },
+      description: 'Called with the value of the selected option',
+    },
+  ],
 }
 export default { title: 'Select', component: Select, parameters: { props } }
 
@@ -18,11 +27,15 @@ let options = optionsFromArray(_.times(lipsum, 5))
 export let usage = () => {
   let [value, setValue] = React.useState(1)
   return (
-    <Grid gap={1}>
+    <Grid gap="sm">
       <div>
         Selected: <b>{value}</b>
       </div>
-      <Select value={value} onChange={setValue} options={options} />
+      <Select
+        value={value}
+        onChange={setValue}
+        options={[{ label: '' }]}
+      />
     </Grid>
   )
 }
@@ -30,7 +43,7 @@ export let usage = () => {
 export let withDomLens = () => {
   let selected = React.useState(1)
   return (
-    <Grid gap={1}>
+    <Grid gap="sm">
       <div>
         Selected: <b>{F.view(selected)}</b>
       </div>
@@ -60,7 +73,7 @@ export let noOptions = () => <Select options={[]} />
 export let native = () => {
   let selected = React.useState(1)
   return (
-    <Grid gap={1}>
+    <Grid gap="sm">
       <div>
         Selected: <b>{F.view(selected)}</b>
       </div>

--- a/src/stories/Select.stories.js
+++ b/src/stories/Select.stories.js
@@ -31,7 +31,17 @@ export let usage = () => {
       <div>
         Selected: <b>{value}</b>
       </div>
-      <Select value={value} onChange={setValue} options={options} />
+      <Select
+        value={value}
+        onChange={setValue}
+        options={[
+          { label: '😂', value: 'joy' },
+          { label: '🦎', value: 'lizard' },
+          { label: '🌞', value: 'sun_with_face' },
+          { label: '👻', value: 'ghost' },
+          { label: '🍆', value: 'eggplant' },
+        ]}
+      />
     </Grid>
   )
 }

--- a/src/stories/Select.stories.js
+++ b/src/stories/Select.stories.js
@@ -31,11 +31,7 @@ export let usage = () => {
       <div>
         Selected: <b>{value}</b>
       </div>
-      <Select
-        value={value}
-        onChange={setValue}
-        options={[{ label: '' }]}
-      />
+      <Select value={value} onChange={setValue} options={options} />
     </Grid>
   )
 }

--- a/src/stories/TableFooter.stories.js
+++ b/src/stories/TableFooter.stories.js
@@ -10,7 +10,7 @@ export let story = () => {
   let totalRecordsLens = React.useState(21)
   return (
     <>
-      <Grid columns={3} gap={1}>
+      <Grid columns={3} gap="sm">
         <div>
           <Text as="div">Page:</Text>{' '}
           <TextInput {...F.domLens.value([page, onChangePage])} />

--- a/src/stories/TableFooter.stories.js
+++ b/src/stories/TableFooter.stories.js
@@ -24,7 +24,7 @@ export let story = () => {
           <TextInput {...F.domLens.value(totalRecordsLens)} />
         </div>
       </Grid>
-      <Divider margin={2} />
+      <Divider margin="md" />
       <TableFooter
         {...{ page, pageSize, onChangePage, onChangePageSize }}
         totalRecords={totalRecordsLens[0]}

--- a/src/stories/Tag.stories.js
+++ b/src/stories/Tag.stories.js
@@ -18,7 +18,7 @@ export let longTag = () => (
 export let styling = () => {
   let colorFromValue = value => ({ color: value })
   return (
-    <Grid placeItems="start" gap={1}>
+    <Grid placeItems="start" gap="sm">
       <Tag value="magenta" tagStyle={colorFromValue} />
       <Tag value="limegreen" tagStyle={colorFromValue} />
       <Tag

--- a/src/stories/TagsInput.stories.js
+++ b/src/stories/TagsInput.stories.js
@@ -54,7 +54,7 @@ export let baseUsage = () => {
         addTag={tag => setTags(F.push(tag))}
         removeTag={tag => setTags(_.pull(tag))}
       />
-      <Divider margin={2} />
+      <Divider margin="md" />
       <code>{JSON.stringify(tags)}</code>
     </>
   )
@@ -69,7 +69,7 @@ export let empty = () => {
         addTag={tag => setTags(F.push(tag))}
         removeTag={tag => setTags(_.pull(tag))}
       />
-      <Divider margin={2} />
+      <Divider margin="md" />
       <code>{JSON.stringify(tags)}</code>
     </>
   )
@@ -85,7 +85,7 @@ export let flipped = () => {
         addTag={tag => setTags(F.push(tag))}
         removeTag={tag => setTags(_.pull(tag))}
       />
-      <Divider margin={2} />
+      <Divider margin="md" />
       <code>{JSON.stringify(tags)}</code>
     </>
   )

--- a/src/stories/TextHighlight.stories.js
+++ b/src/stories/TextHighlight.stories.js
@@ -11,7 +11,7 @@ let text = _.times(() => loremIpsum({ units: 'paragraph' }), 3)
 export let usage = () => {
   let filter = React.useState('')
   return (
-    <Grid gap={1}>
+    <Grid gap="sm">
       <TextInput
         placeholder="Enter text to highlight..."
         {...F.domLens.value(filter)}

--- a/src/stories/Tooltip.stories.js
+++ b/src/stories/Tooltip.stories.js
@@ -5,7 +5,7 @@ import { loremIpsum } from 'lorem-ipsum'
 export default { title: 'Tooltip', component: Tooltip }
 
 export let basicUsage = () => (
-  <Grid gap={1} placeItems="start">
+  <Grid gap="sm" placeItems="start">
     <a data-tip="hello world">hover me</a>
     <Button data-tip="it is a button">is it a button?</Button>
     <DropdownItem

--- a/src/stories/refs.stories.js
+++ b/src/stories/refs.stories.js
@@ -9,7 +9,7 @@ let textArea
 export default { title: 'Refs' }
 
 export let story = () => (
-  <Grid gap={1}>
+  <Grid gap="sm">
     <TextInput ref={e => (input = e)} placeholder="Text input" />
     <Textarea ref={e => (textArea = e)} placeholder="Textarea" />
     <Select

--- a/src/stories/templates/PageHeader.stories.js
+++ b/src/stories/templates/PageHeader.stories.js
@@ -36,7 +36,7 @@ export let story = () => {
         borderBottom: `1px solid ${theme.colors.neutrals[0]}`,
       }}
     >
-      <Flex gap={1} alignItems="center">
+      <Flex gap="sm" alignItems="center">
         <Subtitle large>Section</Subtitle>
         <SubSection active label="Sub-section 1" />
         <SubSection label="Sub-section 2" />
@@ -48,7 +48,7 @@ export let story = () => {
         <Dropdown trigger="icon" />
       </Flex>
 
-      <Flex gap={1}>
+      <Flex gap="sm">
         <Button info small icon="map">
           Product Tour
         </Button>
@@ -70,7 +70,7 @@ export let DetailHeader = () => (
     }}
   >
     <Title large>Page title</Title>
-    <Flex alignItems="center" gap={1}>
+    <Flex alignItems="center" gap="sm">
       <Button primary>Primary</Button>
       <Dropdown trigger="icon" icon="notifications" />
       <Dropdown trigger="icon" icon="share" />

--- a/src/stories/templates/SpacingDemo.stories.js
+++ b/src/stories/templates/SpacingDemo.stories.js
@@ -25,7 +25,7 @@ export let withInlineContent = () => {
         {...F.domLens.value(component)}
       />
       <Divider margin={2} />
-      <Dynamic component={components[F.view(component)]} gap={1}>
+      <Dynamic component={components[F.view(component)]} gap="sm">
         {inlineContent}
       </Dynamic>
     </>
@@ -59,7 +59,7 @@ export let columns = () => {
       <Dynamic
         component={components[F.view(component)]}
         // both Grid and ColumnList
-        gap={1}
+        gap="sm"
         // Grid property
         columns={2}
         // ColumnList properties

--- a/src/stories/templates/SpacingDemo.stories.js
+++ b/src/stories/templates/SpacingDemo.stories.js
@@ -24,7 +24,7 @@ export let withInlineContent = () => {
         options={F.autoLabelOptions(_.keys(components))}
         {...F.domLens.value(component)}
       />
-      <Divider margin={2} />
+      <Divider margin="md" />
       <Dynamic component={components[F.view(component)]} gap="sm">
         {inlineContent}
       </Dynamic>
@@ -55,7 +55,7 @@ export let columns = () => {
         options={F.autoLabelOptions(_.keys(components))}
         {...F.domLens.value(component)}
       />
-      <Divider margin={2} />
+      <Divider margin="md" />
       <Dynamic
         component={components[F.view(component)]}
         // both Grid and ColumnList

--- a/src/stories/typography/Subtitle.stories.js
+++ b/src/stories/typography/Subtitle.stories.js
@@ -30,7 +30,7 @@ export let largeVariant = () => (
 )
 
 export let weightAndItalicsVariants = () => (
-  <Flex column gap={2}>
+  <Flex column gap="md">
     <Subtitle normal>{lipsum()}</Subtitle>
     <Subtitle italic>{lipsum()}</Subtitle>
   </Flex>

--- a/src/stories/typography/Text.stories.js
+++ b/src/stories/typography/Text.stories.js
@@ -43,7 +43,7 @@ export let extraSmallVariant = () => (
 export let asParagraph = _.times(() => <Text as="p">{lipsum()}</Text>, 3)
 
 export let weightAndItalicsVariants = () => (
-  <Flex column gap={2}>
+  <Flex column gap="md">
     <Text bold>{lipsum()}</Text>
     <Text italic>{lipsum()}</Text>
   </Flex>

--- a/src/stories/typography/Title.stories.js
+++ b/src/stories/typography/Title.stories.js
@@ -56,7 +56,7 @@ export let largeAndSmallVariantsSimultaneously = () => (
 )
 
 export let weightAndItalicsVariants = () => (
-  <Flex column gap={2}>
+  <Flex column gap="md">
     <Title bold>{lipsum()}</Title>
     <Title italic>{lipsum()}</Title>
     <Title small normal>{lipsum()}</Title>


### PR DESCRIPTION
branched from #23

this PR just removes the theme spacing stuff from `gap`, `padding` etc props - we still have aliases (`xs`, `sm`, `md`, `lg`), but numeric values are used as raw pixels instead of multiplied by 8 now