### PR TITLE
fix button error message

### DIFF
--- a/src/Button.js
+++ b/src/Button.js
@@ -7,7 +7,7 @@ import { Subtitle, Text } from './Typography'
 import GVIcon from './Icon'
 import Flex from './Flex'
 import theme from './theme'
-import { getVariants, getVariant } from './utils'
+import { getButtonVariants, getButtonVariant } from './utils'
 let { spaces, space, colors } = theme
 
 let colorVariants = _.mapValues(
@@ -64,7 +64,7 @@ let Button = (
   <As
     css={[
       {
-        ...padding(...getVariant(props, paddingVariants)),
+        ...padding(...getButtonVariant(props, paddingVariants)),
         border: 'none',
         outline: 'none',
         cursor: 'pointer',
@@ -74,12 +74,12 @@ let Button = (
       },
       icon && { paddingRight: 0 },
       disabled && { cursor: 'not-allowed', opacity: 0.5 },
-      ...getVariants(props, colorVariants),
+      ...getButtonVariants(props, colorVariants),
     ]}
     {...{ ref, ...props }}
   >
     <Flex alignItems="center" justifyContent="center">
-      {getVariant(props, textVariants)({ children })}
+      {getButtonVariant(props, textVariants)({ children })}
       {icon && (
         <Icon
           {...{ icon, ..._.pick(['large', 'small'], props) }}

--- a/src/utils.js
+++ b/src/utils.js
@@ -40,3 +40,14 @@ export let getVariants = (props, variants, defaultKey = 'default') =>
 
 // Returns only the last variant of getVariants
 export let getVariant = (...args) => _.last(getVariants(...args))
+
+
+//getVariants modification to solve warning problem., use color attribute instead of using boolean to mark button type.
+
+export let getButtonVariants = (props, variants, defaultKey = 'default') =>
+    _.flow(
+        _.pick(_.compact([defaultKey, props.color])),
+        _.values
+    )(variants)
+
+export let getButtonVariant = (...args) => _.last(getColorVariants(...args))


### PR DESCRIPTION
add color attribute to solve the warning message 
![error](https://user-images.githubusercontent.com/10645051/76135681-2e286880-5fde-11ea-9c14-d9203d5ba279.jpg)
also add two  modification(getButtonVariants, getButtonVariant) for  getButtonVariants  and getButtonVariant.

the Button usage example changed to <Button color='primary'> instead of <Button primary>
