### PR TITLE
Grab bag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1713,147 +1713,6 @@
       "integrity": "sha512-4Th98KlMHr5+JkxfcoDT//6vY8vM+iSPrLNpHhRyLx2CFYi8e2RfqPLdpbnpo0Q5lQC5hNB79yes07zb02fvCw==",
       "dev": true
     },
-    "@chromaui/localtunnel": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@chromaui/localtunnel/-/localtunnel-1.10.1.tgz",
-      "integrity": "sha512-LXhAogVc9SOQ45+mtk2mhcQxW4bE8aadfx9WbDzuDlBXcDgDMFBaxOmd5VYsPxQYA+cLFkKeuKOpROzsZSEySA==",
-      "dev": true,
-      "requires": {
-        "axios": "0.19.0",
-        "debug": "^3.0.1",
-        "openurl": "1.1.1",
-        "yargs": "6.6.0"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
-          "dev": true
-        },
-        "cliui": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-          "dev": true,
-          "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wrap-ansi": "^2.0.0"
-          }
-        },
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "find-up": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "dev": true,
-          "requires": {
-            "path-exists": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "invert-kv": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-          "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
-          "dev": true
-        },
-        "lcid": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-          "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-          "dev": true,
-          "requires": {
-            "invert-kv": "^1.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
-        "os-locale": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-          "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-          "dev": true,
-          "requires": {
-            "lcid": "^1.0.0"
-          }
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true,
-          "requires": {
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-          "dev": true,
-          "requires": {
-            "find-up": "^1.0.0",
-            "read-pkg": "^1.0.0"
-          }
-        },
-        "which-module": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-          "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
-          "dev": true
-        },
-        "y18n": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
-          "dev": true
-        },
-        "yargs": {
-          "version": "6.6.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
-          "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
-          "dev": true,
-          "requires": {
-            "camelcase": "^3.0.0",
-            "cliui": "^3.2.0",
-            "decamelize": "^1.1.1",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^1.4.0",
-            "read-pkg-up": "^1.0.1",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^1.0.2",
-            "which-module": "^1.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^4.2.0"
-          }
-        },
-        "yargs-parser": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
-          "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
-          "dev": true,
-          "requires": {
-            "camelcase": "^3.0.0"
-          }
-        }
-      }
-    },
     "@cnakazawa/watch": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.3.tgz",
@@ -3171,9 +3030,9 @@
           }
         },
         "acorn": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
-          "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
+          "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
           "dev": true
         },
         "acorn-jsx": {
@@ -7568,15 +7427,6 @@
       "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
       "dev": true
     },
-    "async-retry": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.1.tgz",
-      "integrity": "sha512-aiieFW/7h3hY0Bq5d+ktDBejxuwR78vRu9hDUdR8rNhSaQ29VzPL4AoIRG7D/c7tdenwOcKvgPM6tIxB3cB6HA==",
-      "dev": true,
-      "requires": {
-        "retry": "0.12.0"
-      }
-    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -7655,24 +7505,6 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
       "dev": true
-    },
-    "axios": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
-      "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
-      "dev": true,
-      "requires": {
-        "follow-redirects": "1.5.10",
-        "is-buffer": "^2.0.2"
-      },
-      "dependencies": {
-        "is-buffer": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
-          "dev": true
-        }
-      }
     },
     "babel-code-frame": {
       "version": "6.26.0",
@@ -10188,12 +10020,6 @@
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
       "dev": true
     },
-    "denodeify": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/denodeify/-/denodeify-1.2.1.tgz",
-      "integrity": "sha1-OjYof1A05pnnV3kBBSwubJQlFjE=",
-      "dev": true
-    },
     "depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -10733,16 +10559,6 @@
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
       "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
       "dev": true
-    },
-    "env-ci": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/env-ci/-/env-ci-2.6.0.tgz",
-      "integrity": "sha512-tnOi9qgtDxY3mvf69coXLHbSZtFMNGAJ1s/huirAhJZTx9rs/1qgFjl+6Z5ULQCfpDmlsf34L7wm+eJGwMazYg==",
-      "dev": true,
-      "requires": {
-        "execa": "^1.0.0",
-        "java-properties": "^0.2.9"
-      }
     },
     "errno": {
       "version": "0.1.7",
@@ -11515,45 +11331,6 @@
       "integrity": "sha512-9sLAvzhI5nc8TpuQUh4ahMdCrWT00wPWz7j47/emR5+2qEfoZP5zzUXvx+vdx+H6ohhnsYC31iX04QLYJK8zTg==",
       "dev": true
     },
-    "execa": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
-      "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
-      "dev": true,
-      "requires": {
-        "cross-spawn": "^6.0.0",
-        "get-stream": "^4.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
-      },
-      "dependencies": {
-        "cross-spawn": {
-          "version": "6.0.5",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-          "dev": true,
-          "requires": {
-            "nice-try": "^1.0.4",
-            "path-key": "^2.0.1",
-            "semver": "^5.5.0",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
-          }
-        },
-        "get-stream": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-          "dev": true,
-          "requires": {
-            "pump": "^3.0.0"
-          }
-        }
-      }
-    },
     "exit": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
@@ -11890,12 +11667,6 @@
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
     },
-    "fake-tag": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/fake-tag/-/fake-tag-1.0.1.tgz",
-      "integrity": "sha512-qmewZoBpa71mM+y6oxXYW/d1xOYQmeIvnEXAt1oCmdP0sqcogWYLepR87QL1jQVLSVMVYDq2cjY6ec/Wu8/4pg==",
-      "dev": true
-    },
     "fast-deep-equal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
@@ -11916,12 +11687,6 @@
         "micromatch": "^3.1.10"
       }
     },
-    "fast-json-parse": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/fast-json-parse/-/fast-json-parse-1.0.3.tgz",
-      "integrity": "sha512-FRWsaZRWEJ1ESVNbDWmsAlqDk96gPQezzLghafp5J4GUKjbCz3OkAHuZs5TuPEtkbVQERysLp9xv6c24fBm8Aw==",
-      "dev": true
-    },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
@@ -11932,12 +11697,6 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-      "dev": true
-    },
-    "fast-safe-stringify": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-1.2.3.tgz",
-      "integrity": "sha512-QJYT/i0QYoiZBQ71ivxdyTqkwKkQ0oxACXHYxH2zYHJEgzi2LsbjgvtzTbLi1SZcF190Db2YP7I7eTsU2egOlw==",
       "dev": true
     },
     "fault": {
@@ -12191,12 +11950,6 @@
         "write": "^0.2.1"
       }
     },
-    "flatstr": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/flatstr/-/flatstr-1.0.12.tgz",
-      "integrity": "sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw==",
-      "dev": true
-    },
     "flow-parser": {
       "version": "0.118.0",
       "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.118.0.tgz",
@@ -12218,26 +11971,6 @@
       "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.6.6.tgz",
       "integrity": "sha512-Dx69IXGCq1qsUExWuG+5wkiMqVM/zGx/reXSJSLogECwp3x6KeNQZ+NAetgxEFpnC41rD8U3+jRCW68+LNzdtw==",
       "dev": true
-    },
-    "follow-redirects": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-      "dev": true,
-      "requires": {
-        "debug": "=3.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
     },
     "for-in": {
       "version": "1.0.2",
@@ -14862,12 +14595,6 @@
         "iterate-iterator": "^1.0.1"
       }
     },
-    "java-properties": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/java-properties/-/java-properties-0.2.10.tgz",
-      "integrity": "sha512-CpKJh9VRNhS+XqZtg1UMejETGEiqwCGDC/uwPEEQwc2nfdbSm73SIE29TplG2gLYuBOOTNDqxzG6A9NtEPLt0w==",
-      "dev": true
-    },
     "jest": {
       "version": "24.7.1",
       "resolved": "https://registry.npmjs.org/jest/-/jest-24.7.1.tgz",
@@ -16476,9 +16203,9 @@
       }
     },
     "kind-of": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true
     },
     "klaw": {
@@ -17458,12 +17185,6 @@
         }
       }
     },
-    "moment": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==",
-      "dev": true
-    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -17555,12 +17276,6 @@
         "lower-case": "^1.1.1"
       }
     },
-    "node-ask": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/node-ask/-/node-ask-1.0.1.tgz",
-      "integrity": "sha1-yqoQdsxY4DZCZ6CQPj6t+sFYOWs=",
-      "dev": true
-    },
     "node-cleanup": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/node-cleanup/-/node-cleanup-2.1.2.tgz",
@@ -17628,17 +17343,6 @@
           "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
           "dev": true
         }
-      }
-    },
-    "node-loggly-bulk": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/node-loggly-bulk/-/node-loggly-bulk-2.2.4.tgz",
-      "integrity": "sha512-DfhtsDfkSBU6Dp1zvK+H1MgHRcA2yb4z07ctyA6uo+bNwKtv1exhohN910zcWNkdSYq1TImCq+O+3bOTuYHvmQ==",
-      "dev": true,
-      "requires": {
-        "json-stringify-safe": "5.0.x",
-        "moment": "^2.18.1",
-        "request": ">=2.76.0 <3.0.0"
       }
     },
     "node-modules-regexp": {
@@ -17992,12 +17696,6 @@
           "dev": true
         }
       }
-    },
-    "openurl": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/openurl/-/openurl-1.1.1.tgz",
-      "integrity": "sha1-OHW0sO96UsFW8NtB1GCduw+Us4c=",
-      "dev": true
     },
     "optimist": {
       "version": "0.6.1",
@@ -18529,33 +18227,6 @@
         "pinkie": "^2.0.0"
       }
     },
-    "pino": {
-      "version": "4.10.2",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-4.10.2.tgz",
-      "integrity": "sha512-hNNDgOju2UvK4iKqXR3ZwEutoOujBRN9jfQgty/X4B3q1QOqpWqvmVn+GT/a20o8Jw5Wd7VkGJAdgFQg55a+mw==",
-      "dev": true,
-      "requires": {
-        "chalk": "^2.3.0",
-        "fast-json-parse": "^1.0.0",
-        "fast-safe-stringify": "^1.2.1",
-        "flatstr": "^1.0.4",
-        "pump": "^1.0.3",
-        "quick-format-unescaped": "^1.1.1",
-        "split2": "^2.2.0"
-      },
-      "dependencies": {
-        "pump": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
-          "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
-          "dev": true,
-          "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
-          }
-        }
-      }
-    },
     "pinpoint": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/pinpoint/-/pinpoint-1.1.0.tgz",
@@ -18659,7 +18330,6 @@
       "version": "3.4.4",
       "resolved": "https://registry.npmjs.org/polished/-/polished-3.4.4.tgz",
       "integrity": "sha512-x9PKeExyI9AhWrJP3Q57I1k7GInujjiVBJMPFmycj9hX1yCOo/X9eu9eZwxgOziiXge3WbFQ5XOmkzunOntBSA==",
-      "dev": true,
       "requires": {
         "@babel/runtime": "^7.6.3"
       },
@@ -18668,7 +18338,6 @@
           "version": "7.8.4",
           "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.4.tgz",
           "integrity": "sha512-neAp3zt80trRVBI1x0azq6c57aNBqYZH8KhMm3TaB7wEI5Q4A2SHfBHE8w9gOhI/lrqxtEbXZgQIrHP+wvSGwQ==",
-          "dev": true,
           "requires": {
             "regenerator-runtime": "^0.13.2"
           }
@@ -18676,8 +18345,7 @@
         "regenerator-runtime": {
           "version": "0.13.3",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
-          "dev": true
+          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
         }
       }
     },
@@ -18881,16 +18549,6 @@
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
-    },
-    "progress-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/progress-stream/-/progress-stream-2.0.0.tgz",
-      "integrity": "sha1-+sY6Cz0R3qy7CWmrzJOyFLzhntU=",
-      "dev": true,
-      "requires": {
-        "speedometer": "~1.0.0",
-        "through2": "~2.0.3"
-      }
     },
     "promise": {
       "version": "7.3.1",
@@ -19365,15 +19023,6 @@
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
       "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==",
       "dev": true
-    },
-    "quick-format-unescaped": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-1.1.2.tgz",
-      "integrity": "sha1-DKWB3jF0vs7yWsPC6JVjQjgdtpg=",
-      "dev": true,
-      "requires": {
-        "fast-safe-stringify": "^1.0.8"
-      }
     },
     "raf": {
       "version": "3.4.1",
@@ -20155,15 +19804,31 @@
       }
     },
     "react-inspector": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/react-inspector/-/react-inspector-4.0.0.tgz",
-      "integrity": "sha512-heh4THBeJg0HLYO/3VBAOaFPkdEHoTZq9VFgP4rOzGw/jyqdVd5spfXSl3LNB1fwrwaWef75Q1hCuwlY4GaKjQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/react-inspector/-/react-inspector-4.0.1.tgz",
+      "integrity": "sha512-xSiM6CE79JBqSj8Fzd9dWBHv57tLTH7OM57GP3VrE5crzVF3D5Khce9w1Xcw75OAbvrA0Mi2vBneR1OajKmXFg==",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.26.0",
+        "@babel/runtime": "^7.6.3",
         "is-dom": "^1.0.9",
-        "prop-types": "^15.6.1",
-        "storybook-chromatic": "^2.2.2"
+        "prop-types": "^15.6.1"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.8.7",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.7.tgz",
+          "integrity": "sha512-+AATMUFppJDw6aiR5NVPHqIQBlV/Pj8wY/EZH+lmvRdUo9xBaz/rF3alAwFJQavvKfeOlPE7oaaDHVbcySbCsg==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.4",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.4.tgz",
+          "integrity": "sha512-plpwicqEzfEyTQohIKktWigcLzmNStMGwbOUbykx51/29Z3JOGYldaaNGK7ngNXV+UcoqvIMmloZ48Sr74sd+g==",
+          "dev": true
+        }
       }
     },
     "react-is": {
@@ -20321,67 +19986,6 @@
         "loose-envify": "^1.4.0",
         "prop-types": "^15.6.2",
         "react-lifecycles-compat": "^3.0.4"
-      }
-    },
-    "read-pkg": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-      "dev": true,
-      "requires": {
-        "load-json-file": "^1.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^1.0.0"
-      },
-      "dependencies": {
-        "load-json-file": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0",
-            "strip-bom": "^2.0.0"
-          }
-        },
-        "parse-json": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-          "dev": true,
-          "requires": {
-            "error-ex": "^1.2.0"
-          }
-        },
-        "path-type": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
-        },
-        "strip-bom": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "dev": true,
-          "requires": {
-            "is-utf8": "^0.2.0"
-          }
-        }
       }
     },
     "read-pkg-up": {
@@ -21221,12 +20825,6 @@
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
       "dev": true
     },
-    "retry": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
-      "dev": true
-    },
     "rfc6902": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rfc6902/-/rfc6902-3.0.2.tgz",
@@ -21996,12 +21594,6 @@
       "integrity": "sha512-7j8LYJLeY/Yb6ACbQ7F76qy5jHkp0U6jgBfJsk97bwWlVUnUWsAgpyaCvo17h0/RQGnQ036tVDomiwoI4pDkQA==",
       "dev": true
     },
-    "speedometer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/speedometer/-/speedometer-1.0.0.tgz",
-      "integrity": "sha1-zWccsGdSwivKM3Di8zREC+T8YuI=",
-      "dev": true
-    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -22009,15 +21601,6 @@
       "dev": true,
       "requires": {
         "extend-shallow": "^3.0.0"
-      }
-    },
-    "split2": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
-      "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
-      "dev": true,
-      "requires": {
-        "through2": "^2.0.2"
       }
     },
     "sprintf-js": {
@@ -22107,75 +21690,6 @@
       "resolved": "https://registry.npmjs.org/store2/-/store2-2.10.0.tgz",
       "integrity": "sha512-tWEpK0snS2RPUq1i3R6OahfJNjWCQYNxq0+by1amCSuw0mXtymJpzmZIeYpA1UAa+7B0grCpNYIbDcd7AgTbFg==",
       "dev": true
-    },
-    "storybook-chromatic": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/storybook-chromatic/-/storybook-chromatic-2.2.2.tgz",
-      "integrity": "sha512-n79eX0MQEHzDCnXqgOjvDOQ1xfBOTyQHy1RNxEMQvZolfAle8YVS0NnRpcW0xh/Ye621Iote3dwFI3uQmlcqPw==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.3.1",
-        "@chromaui/localtunnel": "1.10.1",
-        "async-retry": "^1.1.4",
-        "commander": "^2.9.0",
-        "debug": "^3.0.1",
-        "denodeify": "^1.2.1",
-        "env-ci": "^2.1.0",
-        "fake-tag": "^1.0.0",
-        "jsdom": "^11.5.1",
-        "jsonfile": "^4.0.0",
-        "minimatch": "^3.0.4",
-        "node-ask": "^1.0.1",
-        "node-fetch": "^2.6.0",
-        "node-loggly-bulk": "^2.2.4",
-        "param-case": "^2.1.1",
-        "pino": "4.10.2",
-        "progress": "^2.0.3",
-        "progress-stream": "^2.0.0",
-        "semver": "^6.2.0",
-        "strip-color": "^0.1.0",
-        "tmp": "^0.1.0",
-        "tree-kill": "^1.1.0",
-        "uuid": "^3.3.2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
-        "node-fetch": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
-          "dev": true
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
-        },
-        "tmp": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
-          "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
-          "dev": true,
-          "requires": {
-            "rimraf": "^2.6.3"
-          }
-        }
-      }
     },
     "stream-browserify": {
       "version": "2.0.2",
@@ -22495,12 +22009,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-      "dev": true
-    },
-    "strip-color": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/strip-color/-/strip-color-0.1.0.tgz",
-      "integrity": "sha1-EG9l09PmotlAHKwOsM6LinArT3s=",
       "dev": true
     },
     "strip-eof": {
@@ -23528,12 +23036,6 @@
       "requires": {
         "punycode": "^2.1.0"
       }
-    },
-    "tree-kill": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
-      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
-      "dev": true
     },
     "trim": {
       "version": "0.0.1",

--- a/src/Banner.js
+++ b/src/Banner.js
@@ -1,5 +1,6 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/core'
+import _ from 'lodash/fp'
 import { Icon, Text, Flex } from '.'
 import theme from './theme'
 import { getVariant } from './utils'
@@ -36,7 +37,7 @@ let Banner = ({ children, icon, ...props }) => {
       justifyContent="center"
       css={[{ padding: theme.spaces.xs }, styleFromVariant(variant)]}
       gap="xs"
-      {...props}
+      {..._.omit(_.keys(variants), props)}
     >
       <Icon
         icon={icon || variant.icon}

--- a/src/Banner.js
+++ b/src/Banner.js
@@ -1,9 +1,8 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/core'
-import _ from 'lodash/fp'
 import { Icon, Text, Flex } from '.'
 import theme from './theme'
-import { getVariant } from './utils'
+import { getVariant, omitKeysFrom } from './utils'
 let { colors } = theme
 
 let styleFromVariant = ({ backgroundColor, textColor }) => ({
@@ -37,7 +36,7 @@ let Banner = ({ children, icon, ...props }) => {
       justifyContent="center"
       css={[{ padding: theme.spaces.xs }, styleFromVariant(variant)]}
       gap="xs"
-      {..._.omit(_.keys(variants), props)}
+      {...omitKeysFrom(variants, props)}
     >
       <Icon
         icon={icon || variant.icon}

--- a/src/Box.js
+++ b/src/Box.js
@@ -24,7 +24,7 @@ let Box = (
         [paddingX, _.last(_.castArray(padding))],
       ]),
     }}
-    {...{ ref, ...props }}
+    {...{ ref, ..._.omit(_.keys(theme.boxShadows), props) }}
   />
 )
 

--- a/src/Box.js
+++ b/src/Box.js
@@ -4,7 +4,7 @@ import _ from 'lodash/fp'
 import F from 'futil'
 import { forwardRef } from 'react'
 import { padding as pad } from 'polished'
-import { getVariants, coalesce } from './utils'
+import { getVariants, coalesce, omitKeysFrom } from './utils'
 import theme from './theme'
 
 let Box = (
@@ -24,7 +24,7 @@ let Box = (
         [paddingX, _.last(_.castArray(padding))],
       ]),
     }}
-    {...{ ref, ..._.omit(_.keys(theme.boxShadows), props) }}
+    {...{ ref, ...omitKeysFrom(theme.boxShadows, props) }}
   />
 )
 

--- a/src/Button.js
+++ b/src/Button.js
@@ -7,7 +7,7 @@ import { Subtitle, Text } from './Typography'
 import GVIcon from './Icon'
 import Flex from './Flex'
 import theme from './theme'
-import { getVariants, getVariant } from './utils'
+import { getVariants, getVariant, omitKeysFrom } from './utils'
 let { spaces, space, colors } = theme
 
 let colorVariants = _.mapValues(
@@ -54,7 +54,7 @@ let textVariants = {
   default: x => <Subtitle {...x} />,
 }
 
-let variantKeys = [..._.keys(colorVariants), ..._.keys(textVariants)]
+let omitVariants = omitKeysFrom([colorVariants, textVariants])
 
 let paddings = { small: [0.5, 1], large: [2, 2], default: [1, 2] }
 let paddingVariants = _.mapValues(_.map(space), paddings)
@@ -78,7 +78,7 @@ let Button = (
       disabled && { cursor: 'not-allowed', opacity: 0.5 },
       ...getVariants(props, colorVariants),
     ]}
-    {...{ ref, ..._.omit(variantKeys, props) }}
+    {...{ ref, ...omitVariants(props) }}
   >
     <Flex alignItems="center" justifyContent="center">
       {getVariant(props, textVariants)({ children })}

--- a/src/Button.js
+++ b/src/Button.js
@@ -54,6 +54,8 @@ let textVariants = {
   default: x => <Subtitle {...x} />,
 }
 
+let variantKeys = [..._.keys(colorVariants), ..._.keys(textVariants)]
+
 let paddings = { small: [0.5, 1], large: [2, 2], default: [1, 2] }
 let paddingVariants = _.mapValues(_.map(space), paddings)
 
@@ -76,7 +78,7 @@ let Button = (
       disabled && { cursor: 'not-allowed', opacity: 0.5 },
       ...getVariants(props, colorVariants),
     ]}
-    {...{ ref, ...props }}
+    {...{ ref, ..._.omit(variantKeys, props) }}
   >
     <Flex alignItems="center" justifyContent="center">
       {getVariant(props, textVariants)({ children })}

--- a/src/Checkbox.js
+++ b/src/Checkbox.js
@@ -26,7 +26,7 @@ let Checkbox = ({
         backgroundColor: theme.colors.backgrounds[0],
         border: `2px solid ${theme.colors.neutrals[2]}`,
         transition: 'all 0.5s ease',
-        '& i': { 
+        '& i': {
           color: checked ? theme.colors.primary : 'transparent',
         },
       },
@@ -44,13 +44,10 @@ let Checkbox = ({
     <input
       type="checkbox"
       style={{ display: 'none' }}
-      {...{ checked, onChange: disabled ? () => {} : onChange }}
+      onChange={e => !disabled && onChange(e.target.value)}
+      checked={checked}
     />
-    <Icon
-      icon="check"
-      size={0}
-      style={{ fontWeight: 'bold' }}
-    />
+    <Icon icon="check" size={0} style={{ fontWeight: 'bold' }} />
   </Flex>
 )
 export default Checkbox

--- a/src/DateInput.js
+++ b/src/DateInput.js
@@ -17,7 +17,7 @@ let { inputStyle, fonts } = theme
 let NativeDateInput = ({ value, onChange = _.noop, ...props }) => (
   <input
     type="date"
-    onChange={x => onChange(toDate(x.target.value))}
+    onChange={e => onChange(toDate(e.target.value))}
     value={toDateWith(toHyphenatedDateString)(value)}
     css={[fonts.Text, inputStyle]}
     {...props}

--- a/src/DateTimeInput.js
+++ b/src/DateTimeInput.js
@@ -17,7 +17,7 @@ let { inputStyle, fonts } = theme
 let NativeDateInput = ({ value, onChange = _.noop, ...props }) => (
   <input
     type="datetime-local"
-    onChange={x => onChange(toDate(x.target.value))}
+    onChange={e => onChange(toDate(e.target.value))}
     value={toDateWith(toLocalISOString)(value)}
     {...props}
     css={[fonts.Text, inputStyle]}

--- a/src/Icon.js
+++ b/src/Icon.js
@@ -14,7 +14,7 @@ let Icon = React.forwardRef(({ icon, style, className, ...props }, ref) =>
     <i
       className={`material-icons ${className}`}
       style={{ fontSize: getVariant(props, sizeVariants), ...style }}
-      {...{ ref, ...props }}
+      {...{ ref, ..._.omit(_.keys(sizes), props) }}
     >
       {icon}
     </i>

--- a/src/Icon.js
+++ b/src/Icon.js
@@ -2,7 +2,7 @@ import React from 'react'
 import F from 'futil'
 import _ from 'lodash/fp'
 import theme from './theme'
-import { getVariant } from './utils'
+import { getVariant, omitKeysFrom } from './utils'
 
 let sizes = { default: 2, small: 1, large: 4 }
 let sizeVariants = _.mapValues(F.getIn(theme.fontSizes), sizes)
@@ -14,7 +14,7 @@ let Icon = React.forwardRef(({ icon, style, className, ...props }, ref) =>
     <i
       className={`material-icons ${className}`}
       style={{ fontSize: getVariant(props, sizeVariants), ...style }}
-      {...{ ref, ..._.omit(_.keys(sizes), props) }}
+      {...{ ref, ...omitKeysFrom(sizeVariants, props) }}
     >
       {icon}
     </i>

--- a/src/PageSize.js
+++ b/src/PageSize.js
@@ -1,6 +1,8 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/core'
 import _ from 'lodash/fp'
+import { observer } from 'mobx-react'
+import { margin } from 'polished'
 import GVPagerItem from './PagerItem'
 import { Text } from './Typography'
 import Flex from './Flex'
@@ -12,27 +14,35 @@ let PageSize = ({
   sizeOptions = [10, 20, 50, 100, 250],
   PagerItem = GVPagerItem,
   ...props
-}) => (
-  <Flex alignItems="baseline" {...props}>
-    <Text small bold css={{ marginRight: theme.spaces.xs }}>View</Text>
-    {_.map(
-      size => (
-        <PagerItem
-          key={size}
-          active={size === value}
-          onClick={() => onChange(size)}
-          css={{ margin: 2 }}
-        >
-          {size}
-        </PagerItem>
-      ),
-      _.flow(
-        _.concat(value),
-        _.sortBy(_.identity),
-        _.sortedUniq
-      )(sizeOptions)
-    )}
-  </Flex>
-)
+}) => {
+  value = _.toInteger(value) || 10
+  return (
+    <Flex alignItems="baseline" {...props}>
+      <Text small bold css={{ marginRight: theme.spaces.xs }}>
+        View
+      </Text>
+      {_.map(
+        size => {
+          let active = size === value
+          return (
+            <PagerItem
+              key={size}
+              active={active}
+              onClick={() => onChange(size)}
+              css={active && margin(0, theme.spaces.xs)}
+            >
+              {size}
+            </PagerItem>
+          )
+        },
+        _.flow(
+          _.concat(value),
+          _.sortBy(_.identity),
+          _.sortedUniq
+        )(sizeOptions)
+      )}
+    </Flex>
+  )
+}
 
-export default PageSize
+export default observer(PageSize)

--- a/src/PageSize.js
+++ b/src/PageSize.js
@@ -1,7 +1,6 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/core'
 import _ from 'lodash/fp'
-import { observer } from 'mobx-react'
 import { margin } from 'polished'
 import GVPagerItem from './PagerItem'
 import { Text } from './Typography'
@@ -45,4 +44,4 @@ let PageSize = ({
   )
 }
 
-export default observer(PageSize)
+export default PageSize

--- a/src/PageSize.js
+++ b/src/PageSize.js
@@ -9,12 +9,12 @@ import theme from './theme'
 let PageSize = ({
   value,
   onChange = () => {},
-  sizeOptions = [20, 50, 100, 250],
+  sizeOptions = [10, 20, 50, 100, 250],
   PagerItem = GVPagerItem,
   ...props
 }) => (
   <Flex alignItems="baseline" {...props}>
-    <Text small css={{ marginRight: theme.spaces.xs, fontWeight: 'bold' }}>View</Text>
+    <Text small bold css={{ marginRight: theme.spaces.xs }}>View</Text>
     {_.map(
       size => (
         <PagerItem

--- a/src/Pager.js
+++ b/src/Pager.js
@@ -12,8 +12,9 @@ let Pager = ({
   PagerItem = GVPagerItem,
   Icon = GVIcon,
   ...props
-}) =>
-  pageCount > 1 && (
+}) => {
+  value = _.toInteger(value) || 1
+  return pageCount <= 1 ? null : (
     <Flex justifyContent="center" alignItems="center" gap="xs" {...props}>
       <PagerItem disabled={!(value > 1)} onClick={() => onChange(value - 1)}>
         <Icon icon="chevron_left" />
@@ -63,5 +64,6 @@ let Pager = ({
       </PagerItem>
     </Flex>
   )
+}
 
 export default Pager

--- a/src/TableFooter.js
+++ b/src/TableFooter.js
@@ -1,49 +1,71 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/core'
+import F from 'futil'
 import _ from 'lodash/fp'
 import Pager from './Pager'
+import PagerItem from './PagerItem'
 import PageSize from './PageSize'
 import Flex from './Flex'
 import { Text } from './Typography'
 import theme from './theme'
 
-let showing = (totalRecords, page, pageSize) => {
-  let min = _.min([totalRecords, pageSize * (page - 1) + 1])
-  let max = _.min([totalRecords, pageSize * page])
-  return min >= max ? max : `${min}-${max}`
-}
+let PageDetails = ({ startRecord, endRecord, totalRecords, hasMore }) => (
+  <Text small css={{ flex: '0 1 30%', textAlign: 'right' }}>
+    <b>Showing </b>
+    {startRecord >= endRecord ? endRecord : `${startRecord}-${endRecord}`}
+    {F.isNotNil(totalRecords) && ` of ${totalRecords}${hasMore ? '+' : ''}`}
+  </Text>
+)
 
+// Requires either `totalRecords` or `hasMore` to do pagination properly.
+// `hasMore` is a flag signifying that there is at least one page of records
+// after the current one; it allows us to support some pagination functionality
+// even when `totalRecords` is not given (eg. for APIs that return paginated
+// results without a total count).
 let TableFooter = ({
   page = 1,
   onChangePage,
   pageSize,
   onChangePageSize,
   pageSizeOptions,
-  totalRecords = 0,
+  hasMore,
+  totalRecords,
+  startRecord = pageSize * (page - 1) + 1,
+  endRecord = hasMore ? page * pageSize : 0,
   ...props
-}) => (
-  <Flex
-    justifyContent="space-between"
-    alignItems="center"
-    css={{ marginTop: theme.spaces.sm }}
-    {...props}
-  >
-    <PageSize
-      sizeOptions={pageSizeOptions}
-      value={pageSize}
-      onChange={onChangePageSize}
-      css={{ flex: 1 }}
-    />
-    <Pager
-      css={{ flex: 1 }}
-      value={page}
-      onChange={onChangePage}
-      pageCount={_.ceil(totalRecords / pageSize)}
-    />
-    <Text small css={{ flex: 1, textAlign: 'right' }}>
-      <b>Showing</b> {showing(totalRecords, page, pageSize)} of {totalRecords}
-    </Text>
-  </Flex>
-)
+}) => {
+  // if endRecord isn't given, approximate it from totalRecords
+  if (totalRecords)
+    endRecord = endRecord || _.min([page * pageSize, totalRecords])
+  if (!hasMore && !totalRecords) totalRecords = endRecord
+  let pageCount = _.ceil((totalRecords || endRecord) / pageSize)
+  return (
+    <Flex
+      justifyContent="space-between"
+      alignItems="center"
+      css={{ padding: theme.spaces.sm }}
+      {...props}
+    >
+      <PageSize
+        sizeOptions={pageSizeOptions}
+        value={pageSize}
+        onChange={onChangePageSize}
+        css={{ flex: '0 1 30%' }}
+      />
+      <Flex css={{ flex: 1 }} alignItems="center" justifyContent="center">
+        <Pager value={page} onChange={onChangePage} pageCount={pageCount} />
+        {hasMore && page >= pageCount && (
+          <PagerItem
+            style={{ margin: '0 8px', paddingLeft: 12, paddingRight: 12 }}
+            onClick={() => onChangePage(page + 1)}
+          >
+            Load More...
+          </PagerItem>
+        )}
+      </Flex>
+      <PageDetails {...{ totalRecords, startRecord, endRecord, hasMore }} />
+    </Flex>
+  )
+}
 
 export default TableFooter

--- a/src/TableFooter.js
+++ b/src/TableFooter.js
@@ -49,7 +49,10 @@ let TableFooter = ({
       <PageSize
         sizeOptions={pageSizeOptions}
         value={pageSize}
-        onChange={onChangePageSize}
+        onChange={size => {
+          onChangePage(_.ceil((startRecord || 0) / size) || 1)
+          onChangePageSize(size)
+        }}
         css={{ flex: '0 1 30%' }}
       />
       <Flex css={{ flex: 1 }} alignItems="center" justifyContent="center">

--- a/src/TextInput.js
+++ b/src/TextInput.js
@@ -5,10 +5,18 @@ import { observer } from 'mobx-react'
 import _ from 'lodash/fp'
 import theme from './theme'
 
-let TextInput = ({ type = 'text', disabled, error, ...props }, ref) => (
+let TextInput = (
+  { type = 'text', disabled, error, onChange, ...props },
+  ref
+) => (
   <input
+    onChange={e => onChange(e.target.value)}
     {...{ type, ref, disabled, ...props }}
-    css={[theme.inputStyle, theme.fonts.Text, error && { borderColor: theme.colors.error }]}
+    css={[
+      theme.inputStyle,
+      theme.fonts.Text,
+      error && { borderColor: theme.colors.error },
+    ]}
   />
 )
 

--- a/src/Typography.js
+++ b/src/Typography.js
@@ -2,7 +2,7 @@
 import { jsx } from '@emotion/core'
 import { forwardRef } from 'react'
 import _ from 'lodash/fp'
-import { getVariants } from './utils'
+import { getVariants, omitKeysFrom } from './utils'
 import theme from './theme'
 
 let modifiers = {
@@ -15,7 +15,7 @@ let toComponent = ({ variants, ...styles }) =>
   forwardRef(({ as: As = 'span', ...props }, ref) => (
     <As
       css={[styles, ...getVariants(props, { ...variants, ...modifiers })]}
-      {...{ ref, ...props }}
+      {...{ ref, ...omitKeysFrom([variants, modifiers], props) }}
     />
   ))
 

--- a/src/stories/TableFooter.stories.js
+++ b/src/stories/TableFooter.stories.js
@@ -12,15 +12,23 @@ export let story = () => {
       <Grid columns={3} gap="sm">
         <div>
           <Text as="div">Page:</Text>
-          <TextInput value={page} onChange={onChangePage} />
+          <TextInput type="number" value={page} onChange={onChangePage} />
         </div>
         <div>
           <Text as="div">Page Size:</Text>
-          <TextInput value={pageSize} onChange={onChangePageSize} />
+          <TextInput
+            type="number"
+            value={pageSize}
+            onChange={onChangePageSize}
+          />
         </div>
         <div>
           <Text as="div">Total Records:</Text>
-          <TextInput value={totalRecords} onChange={setTotalRecords} />
+          <TextInput
+            type="number"
+            value={totalRecords}
+            onChange={setTotalRecords}
+          />
         </div>
       </Grid>
       <Divider margin="md" />

--- a/src/stories/TableFooter.stories.js
+++ b/src/stories/TableFooter.stories.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import F from 'futil'
 import { TableFooter, TextInput, Text, Grid, Divider } from '..'
 
 export default { title: 'TableFooter', component: TableFooter }
@@ -7,27 +6,27 @@ export default { title: 'TableFooter', component: TableFooter }
 export let story = () => {
   let [page, onChangePage] = React.useState(1)
   let [pageSize, onChangePageSize] = React.useState(20)
-  let totalRecordsLens = React.useState(21)
+  let [totalRecords, setTotalRecords] = React.useState(21)
   return (
     <>
       <Grid columns={3} gap="sm">
         <div>
-          <Text as="div">Page:</Text>{' '}
-          <TextInput {...F.domLens.value([page, onChangePage])} />
+          <Text as="div">Page:</Text>
+          <TextInput value={page} onChange={onChangePage} />
         </div>
         <div>
-          <Text as="div">Page Count:</Text>{' '}
-          <TextInput {...F.domLens.value([pageSize, onChangePageSize])} />
+          <Text as="div">Page Size:</Text>
+          <TextInput value={pageSize} onChange={onChangePageSize} />
         </div>
         <div>
-          <Text as="div">Total Records:</Text>{' '}
-          <TextInput {...F.domLens.value(totalRecordsLens)} />
+          <Text as="div">Total Records:</Text>
+          <TextInput value={totalRecords} onChange={setTotalRecords} />
         </div>
       </Grid>
       <Divider margin="md" />
       <TableFooter
         {...{ page, pageSize, onChangePage, onChangePageSize }}
-        totalRecords={totalRecordsLens[0]}
+        totalRecords={totalRecords}
       />
     </>
   )

--- a/src/stories/TableFooter.stories.js
+++ b/src/stories/TableFooter.stories.js
@@ -1,7 +1,20 @@
 import React from 'react'
 import { TableFooter, TextInput, Text, Grid, Divider } from '..'
 
-export default { title: 'TableFooter', component: TableFooter }
+let props = {
+  rows: [
+    { name: 'page', type: { summary: 'integer' } },
+    { name: 'onChangePage', type: { summary: 'function' } },
+    { name: 'pageSize', type: { summary: 'integer' } },
+    { name: 'onChangePageSize', type: { summary: 'function' } },
+  ],
+}
+
+export default {
+  title: 'TableFooter',
+  component: TableFooter,
+  parameters: { props },
+}
 
 export let story = () => {
   let [page, onChangePage] = React.useState(1)

--- a/src/utils.js
+++ b/src/utils.js
@@ -40,3 +40,9 @@ export let getVariants = (props, variants, defaultKey = 'default') =>
 
 // Returns only the last variant of getVariants
 export let getVariant = (...args) => _.last(getVariants(...args))
+
+let keysAll = _.flow(
+  _.castArray,
+  _.reduce((acc, x) => _.union(_.keys(x), acc), [])
+)
+export let omitKeysFrom = _.curry((objs, x) => _.omit(keysAll(objs), x))


### PR DESCRIPTION
Don't mind the branch name, this PR is a 3-for-1:

1. Port over updates to the TableFooter family of components (PageSize, Pager, etc) from contexture-react, plus fix some stuff in the components & improve the TableFooter story

2. No longer pass variant flags through to child components (should stop those pesky React console errors & obviate #27)

3. Convert the rest of our `onChange` callbacks to pass the plain value instead of an event (I thought I did this already but apparently I missed a bunch of them)