### PR TITLE
Native select default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,11 @@ Component props that control whitespace now take the following spacing aliases f
 
 <hr />
 
+#### 3.0.0-alpha.26
+
+- Use native Select component by default
+- Move JavaScript Select component under `custom` opt-in
+
 #### 3.0.0-alpha.25
 
 - Checkbox: add support for labels, add prop documentation, improve stories

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grey-vest",
-  "version": "3.0.0-alpha.25",
+  "version": "3.0.0-alpha.26",
   "description": "GreyVest component library",
   "main": "dist/index.js",
   "scripts": {

--- a/src/Select.js
+++ b/src/Select.js
@@ -86,10 +86,10 @@ let ReactSelect = ({ value, options, onChange, ...props }) => (
 )
 
 let Select = (
-  { options, native = false, placeholder = 'Please Select...', ...props },
+  { options, custom = false, placeholder = 'Please Select...', ...props },
   ref
 ) => {
-  let Component = native ? NativeSelect : ReactSelect
+  let Component = custom ? ReactSelect : NativeSelect 
   return <Component {...{ options, placeholder, ref, ...props }} />
 }
 

--- a/src/docs/variants.stories.mdx
+++ b/src/docs/variants.stories.mdx
@@ -61,6 +61,7 @@ In addition to these, there are some common flags in GreyVest that are supported
 | Flag       | Supported components                                  | Purpose                                                                                           |
 | ---------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
 | `native`   | DateInput, RadioList                          | Use native form elements instead of JS implementations                                            |
+| `custom`   | Select                          | Use `react-select` select elements instead of native form elements                                            |
 | `active`   | Button, PagerItem, PickerItem                         | Update styling to convey that the item is currently active                                        |
 | `disabled` | Button, Checkbox, DropdownItem, PagerItem, PickerItem | Disable input and events on the component, and update styling to convey that the item is disabled |
 

--- a/src/docs/variants.stories.mdx
+++ b/src/docs/variants.stories.mdx
@@ -60,7 +60,7 @@ In addition to these, there are some common flags in GreyVest that are supported
 
 | Flag       | Supported components                                  | Purpose                                                                                           |
 | ---------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| `native`   | DateInput, RadioList, Select                          | Use native form elements instead of JS implementations                                            |
+| `native`   | DateInput, RadioList                          | Use native form elements instead of JS implementations                                            |
 | `active`   | Button, PagerItem, PickerItem                         | Update styling to convey that the item is currently active                                        |
 | `disabled` | Button, Checkbox, DropdownItem, PagerItem, PickerItem | Disable input and events on the component, and update styling to convey that the item is disabled |
 

--- a/src/stories/Select.stories.js
+++ b/src/stories/Select.stories.js
@@ -59,13 +59,13 @@ takes any valid [futil](https://github.com/smartprocure/futil-js) lens format
 
 export let noOptions = () => <Select options={[]} />
 
-export let native = () => {
+export let custom = () => {
   let [value, setValue] = React.useState(1)
   return (
     <>
       Selected: <b>{value}</b>
       <Divider />
-      <Select native value={value} onChange={setValue} options={options} />
+      <Select custom value={value} onChange={setValue} options={options} />
     </>
   )
 }


### PR DESCRIPTION
As of [3.0.0-alpha.10](https://github.com/smartprocure/grey-vest/blob/3d0202c9bb7e16fbcaf83b84518264aee59d3e54/CHANGELOG.md#300-alpha10) `react-select` backed Select component is default. 
> Add support (and a story) for the react-select backed Select component, and make it default over native select

Since it is default, it makes sense to have `react-select` listed as a dependency or to avoid the big package size, make the `react-select` backed Select component opt-in.

![rsize](https://user-images.githubusercontent.com/29695350/77692496-b9a96f80-6f74-11ea-99be-cb439ef071b6.png)
161kb

This PR  moves the `react-select` Select component to opt-in and uses native by default.

Alternatively, the other PR #33 moves `react-select` to `dependencies` from `devDependencies`.


-------

This was discovered when using FormField, Select is automatically imported anytime a FormField component is used: 
https://github.com/smartprocure/grey-vest/blob/f0b0d0d02bb48d7ade995b92cab16a652409135c/src/FormField.js#L26
