### PR TITLE
Move react-select to dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,10 @@ Component props that control whitespace now take the following spacing aliases f
 
 <hr />
 
+#### 3.0.0-alpha.26
+
+- Move `react-select` to `dependencies` from `devDependencies`
+
 #### 3.0.0-alpha.25
 
 - Checkbox: add support for labels, add prop documentation, improve stories

--- a/package.json
+++ b/package.json
@@ -104,7 +104,6 @@
     "raw-loader": "^2.0.0",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",
-    "react-select": "^2.0.0",
     "react-test-renderer": "^16.2.0"
   },
   "dependencies": {
@@ -119,6 +118,7 @@
     "react-datetime-picker": "^2.9.0",
     "react-popper-tooltip": "^2.10.1",
     "react-tooltip": "^3.11.1",
+    "react-select": "^2.0.0",
     "recompose": "^0.30.0"
   },
   "readme": "README.md"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grey-vest",
-  "version": "3.0.0-alpha.25",
+  "version": "3.0.0-alpha.26",
   "description": "GreyVest component library",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
As of [3.0.0-alpha.10](https://github.com/smartprocure/grey-vest/blob/3d0202c9bb7e16fbcaf83b84518264aee59d3e54/CHANGELOG.md#300-alpha10) `react-select` backed Select component is default. 
> Add support (and a story) for the react-select backed Select component, and make it default over native select

Since it is default, it makes sense to have `react-select` listed as a dependency or to avoid the big package size, make the `react-select` backed Select component opt-in.

![rsize](https://user-images.githubusercontent.com/29695350/77692496-b9a96f80-6f74-11ea-99be-cb439ef071b6.png)
161kb

This PR moves `react-select` to `dependencies` from `devDependencies`

Alternatively, the other PR #32 moves the `react-select` Select component to opt-in and uses native by default.

-------

This was discovered when using FormField, Select is automatically imported anytime a FormField component is used: 
https://github.com/smartprocure/grey-vest/blob/f0b0d0d02bb48d7ade995b92cab16a652409135c/src/FormField.js#L26
